### PR TITLE
Fix titan cf options

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -5168,11 +5168,13 @@ crocksdb_t* ctitandb_open_column_families(
 // use ctitandb_t for titan specific functions.
 crocksdb_column_family_handle_t* ctitandb_create_column_family(
     crocksdb_t* db,
+    const crocksdb_options_t* column_family_options,
     const ctitandb_options_t* titan_column_family_options,
     const char* column_family_name,
     char** errptr) {
   // Blindly cast db into TitanDB.
   TitanDB* titan_db = reinterpret_cast<TitanDB*>(db->rep);
+  *(ColumnFamilyOptions*)&titan_column_family_options->rep = column_family_options->rep;
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
   SaveError(errptr,
       titan_db->CreateColumnFamily(

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -5136,7 +5136,7 @@ crocksdb_t* ctitandb_open_column_families(
     crocksdb_column_family_handle_t** column_family_handles, char** errptr) {
   std::vector<TitanCFDescriptor> column_families;
   for (int i = 0; i < num_column_families; i++) {
-    *(ColumnFamilyOptions*)&titan_column_family_options[i]->rep =
+    *((ColumnFamilyOptions*)(&titan_column_family_options[i]->rep)) =
         column_family_options[i]->rep;
     column_families.push_back(
         TitanCFDescriptor(std::string(column_family_names[i]),
@@ -5174,7 +5174,9 @@ crocksdb_column_family_handle_t* ctitandb_create_column_family(
     char** errptr) {
   // Blindly cast db into TitanDB.
   TitanDB* titan_db = reinterpret_cast<TitanDB*>(db->rep);
-  *(ColumnFamilyOptions*)&titan_column_family_options->rep = column_family_options->rep;
+  // Copy the ColumnFamilyOptions part of `column_family_options` into `titan_column_family_options`
+  *((ColumnFamilyOptions*)(&titan_column_family_options->rep)) = 
+      column_family_options->rep;
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
   SaveError(errptr,
       titan_db->CreateColumnFamily(

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -2052,6 +2052,7 @@ extern C_ROCKSDB_LIBRARY_API crocksdb_t* ctitandb_open_column_families(
 extern C_ROCKSDB_LIBRARY_API
 crocksdb_column_family_handle_t* ctitandb_create_column_family(
     crocksdb_t* db,
+    const crocksdb_options_t* column_family_options,
     const ctitandb_options_t* titan_column_family_options,
     const char* column_family_name,
     char** errptr);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1929,6 +1929,7 @@ extern "C" {
 
     pub fn ctitandb_create_column_family(
         db: *mut DBInstance,
+        column_family_options: *const Options,
         titan_column_family_options: *const DBTitanDBOptions,
         column_family_name: *const c_char,
         err: *mut *mut c_char,

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -823,6 +823,7 @@ impl DB {
             } else {
                 ffi_try!(ctitandb_create_column_family(
                     self.inner,
+                    cfd.options.inner,
                     cfd.options.titan_inner,
                     cname_ptr
                 ))

--- a/tests/cases/test_titan.rs
+++ b/tests/cases/test_titan.rs
@@ -123,7 +123,7 @@ fn test_titandb() {
     cf_opts.add_table_properties_collector_factory("titan-collector", Box::new(f));
     cf_opts.set_titandb_options(&tdb_opts);
 
-    let db = DB::open_cf(
+    let mut db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
         vec![("default", cf_opts)],
@@ -139,6 +139,13 @@ fn test_titandb() {
         }
         db.flush(true).unwrap();
     }
+
+    let mut cf_opts = ColumnFamilyOptions::new();
+    cf_opts.set_num_levels(4);
+    cf_opts.set_titandb_options(&tdb_opts);
+    db.create_cf(("cf1", cf_opts)).unwrap();
+    let cf1 = db.cf_handle("cf1").unwrap();
+    assert_eq!(db.get_options_cf(cf1).get_num_levels(), 4);
 
     let mut iter = db.iter();
     iter.seek(SeekKey::Start);


### PR DESCRIPTION
Note that, TitanDBOptions is the superclass of RocksDBOptions. But we pass RocksDBOptions with Titan related Options separately, so we should copy the RocksDB part into TitanDBOptions.