### PR TITLE
Fix a memory leak in TitanDBOptions::set_dirname

### DIFF
--- a/src/titan.rs
+++ b/src/titan.rs
@@ -33,8 +33,10 @@ impl TitanDBOptions {
 
     pub fn set_dirname(&mut self, name: &str) {
         let s = CString::new(name).unwrap();
+        // Safety: set_dirname copies the C string into std::string. We
+        // still own s and must drop it.
         unsafe {
-            crocksdb_ffi::ctitandb_options_set_dirname(self.inner, s.into_raw());
+            crocksdb_ffi::ctitandb_options_set_dirname(self.inner, s.as_ptr());
         }
     }
 


### PR DESCRIPTION
Found via valgrind.

Signed-off-by: Brian Anderson <andersrb@gmail.com>