### PR TITLE
Update rocksdb. Update rocksdb and titan branch for tikv 3.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
 	url = https://github.com/pingcap/rocksdb.git
-	branch = tikv-3.0
+	branch = tikv-3.x
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan
 	url = https://github.com/pingcap/titan.git
-	branch = tikv-3.0
+	branch = tikv-3.x


### PR DESCRIPTION
Since both tikv-3.0 and tikv-3.1 are using the same rocksdb, titan and rust-rocksdb branch, changing the branch name to tikv-3.x.

Also update rocksdb with the following change for 3.x branch:
```
b047a2a6d 2019-11-26 yiwu@pingcap.com     Fix DBFlushTest::FireOnFlushCompletedAfterCommittedResult hang (#6018)
7f1d9f2c8 2019-11-26 harrywong@live.com   Removed const fields in copyable classes (#5095)
59f71ee61 2019-11-26 siying.d@fb.com      Rename InternalDBStatsType enum names (#5779)
1ee718b3b 2019-11-26 xy.tao@outlook.com   Fix blob context when db_iter uses seek (#6051)
129ad9c95 2019-11-26 bupt2013211450@gma.. fix unstable unittest caused by #5958 (#6061)
88cd73817 2019-11-26 bupt2013211450@gma.. Fix corruption with intra-L0 on ingested files (#5958)
4d6616422 2019-11-26 thomasf@fb.com       Restrict L0->L0 compaction according to max_compaction_bytes option (#5329)
b829446c8 2019-11-26 yiwu@pingcap.com     Revert "Disable Intra-L0 compaction (#128)"
ae2c5a217 2019-11-26 bupt2013211450@gma.. Fix IngestExternalFile's bug with two_write_queue (#5976)
8664450cf 2019-11-26 anand76@devvm1373... Update bg_error when log flush fails in SwitchMemtable() (#5072)
```

Signed-off-by: Yi Wu <yiwu@pingcap.com>