### PR TITLE
update bindgen version

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -23,7 +23,7 @@ sse = ["libtitan_sys/sse"]
 [build-dependencies]
 cc = "1.0.3"
 cmake = "0.1"
-bindgen = "0.52"
+bindgen = "0.51"
 
 [dependencies.jemalloc-sys]
 version = "0.1.8"


### PR DESCRIPTION
Using bindgen 0.52 will conflict with bindgen 0.51 using by grpcio crate. See https://github.com/tikv/rust-rocksdb/pull/402/files#r359639449

Change to use 0.51 instead.

Signed-off-by: Yi Wu <yiwu@pingcap.com>