### PR TITLE
iterator: fix the behavior about valid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use metadata::{ColumnFamilyMetaData, LevelMetaData, SstFileMetaData};
 pub use perf_context::{get_perf_level, set_perf_level, IOStatsContext, PerfContext, PerfLevel};
 pub use rocksdb::{
     load_latest_options, run_ldb_tool, set_external_sst_file_global_seq_no, BackupEngine, CFHandle,
-    Cache, DBIterator, DBVector, Env, ExternalSstFileInfo, Kv, MapProperty, MemoryAllocator, Range,
+    Cache, DBIterator, DBVector, Env, ExternalSstFileInfo, MapProperty, MemoryAllocator, Range,
     SeekKey, SequentialFile, SstFileReader, SstFileWriter, Writable, WriteBatch, DB,
 };
 pub use rocksdb_options::{
@@ -53,6 +53,9 @@ pub use table_properties::{
 pub use table_properties_collector::TablePropertiesCollector;
 pub use table_properties_collector_factory::TablePropertiesCollectorFactory;
 pub use titan::{TitanBlobIndex, TitanDBOptions};
+
+#[allow(deprecated)]
+pub use rocksdb::Kv;
 
 mod compaction_filter;
 pub mod comparator;

--- a/src/perf_context.rs
+++ b/src/perf_context.rs
@@ -423,9 +423,7 @@ mod test {
 
         let mut iter = db.iter();
         assert!(iter.seek(SeekKey::Start).unwrap());
-        while iter.valid().unwrap() {
-            iter.next().unwrap();
-        }
+        while iter.next().unwrap() {}
         assert_eq!(ctx.internal_key_skipped_count(), n);
         assert_eq!(ctx.internal_delete_skipped_count(), n / 2);
         assert_eq!(ctx.seek_internal_seek_time(), 0);

--- a/src/perf_context.rs
+++ b/src/perf_context.rs
@@ -422,9 +422,9 @@ mod test {
         let mut ctx = PerfContext::get();
 
         let mut iter = db.iter();
-        assert!(iter.seek(SeekKey::Start));
-        while iter.valid() {
-            iter.next();
+        assert!(iter.seek(SeekKey::Start).unwrap());
+        while iter.valid().unwrap() {
+            iter.next().unwrap();
         }
         assert_eq!(ctx.internal_key_skipped_count(), n);
         assert_eq!(ctx.internal_delete_skipped_count(), n / 2);
@@ -439,9 +439,9 @@ mod test {
         assert_eq!(get_perf_level(), PerfLevel::EnableTime);
 
         let mut iter = db.iter();
-        assert!(iter.seek(SeekKey::End));
-        while iter.valid() {
-            iter.prev();
+        assert!(iter.seek(SeekKey::End).unwrap());
+        while iter.valid().unwrap() {
+            iter.prev().unwrap();
         }
         assert_eq!(ctx.internal_key_skipped_count(), n + n / 2);
         assert_eq!(ctx.internal_delete_skipped_count(), n / 2);

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -236,7 +236,7 @@ impl<D: Deref<Target = DB>> DBIterator<D> {
 }
 
 impl<D> DBIterator<D> {
-    pub fn seek(&mut self, key: SeekKey) -> bool {
+    pub fn seek(&mut self, key: SeekKey) -> Result<bool, String> {
         unsafe {
             match key {
                 SeekKey::Start => crocksdb_ffi::crocksdb_iter_seek_to_first(self.inner),
@@ -249,7 +249,7 @@ impl<D> DBIterator<D> {
         self.valid()
     }
 
-    pub fn seek_for_prev(&mut self, key: SeekKey) -> bool {
+    pub fn seek_for_prev(&mut self, key: SeekKey) -> Result<bool, String> {
         unsafe {
             match key {
                 SeekKey::Start => crocksdb_ffi::crocksdb_iter_seek_to_first(self.inner),
@@ -264,7 +264,7 @@ impl<D> DBIterator<D> {
         self.valid()
     }
 
-    pub fn prev(&mut self) -> bool {
+    pub fn prev(&mut self) -> Result<bool, String> {
         unsafe {
             crocksdb_ffi::crocksdb_iter_prev(self.inner);
         }
@@ -272,7 +272,7 @@ impl<D> DBIterator<D> {
     }
 
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> bool {
+    pub fn next(&mut self) -> Result<bool, String> {
         unsafe {
             crocksdb_ffi::crocksdb_iter_next(self.inner);
         }
@@ -280,7 +280,7 @@ impl<D> DBIterator<D> {
     }
 
     pub fn key(&self) -> &[u8] {
-        assert!(self.valid());
+        debug_assert_eq!(self.valid(), Ok(true));
         let mut key_len: size_t = 0;
         let key_len_ptr: *mut size_t = &mut key_len;
         unsafe {
@@ -290,7 +290,7 @@ impl<D> DBIterator<D> {
     }
 
     pub fn value(&self) -> &[u8] {
-        assert!(self.valid());
+        debug_assert_eq!(self.valid(), Ok(true));
         let mut val_len: size_t = 0;
         let val_len_ptr: *mut size_t = &mut val_len;
         unsafe {
@@ -299,16 +299,20 @@ impl<D> DBIterator<D> {
         }
     }
 
-    pub fn kv(&self) -> Option<(Vec<u8>, Vec<u8>)> {
-        if self.valid() {
-            Some((self.key().to_vec(), self.value().to_vec()))
-        } else {
-            None
+    pub fn kv(&self) -> Result<Option<(Vec<u8>, Vec<u8>)>, String> {
+        match self.valid() {
+            Ok(true) => Ok(Some((self.key().to_vec(), self.value().to_vec()))),
+            Ok(false) => Ok(None),
+            Err(e) => Err(e),
         }
     }
 
-    pub fn valid(&self) -> bool {
-        unsafe { crocksdb_ffi::crocksdb_iter_valid(self.inner) }
+    pub fn valid(&self) -> Result<bool, String> {
+        let valid = unsafe { crocksdb_ffi::crocksdb_iter_valid(self.inner) };
+        if !valid {
+            self.status()?;
+        }
+        Ok(valid)
     }
 
     pub fn status(&self) -> Result<(), String> {
@@ -319,17 +323,20 @@ impl<D> DBIterator<D> {
     }
 }
 
-pub type Kv = (Vec<u8>, Vec<u8>);
+pub type Kv = Result<(Vec<u8>, Vec<u8>), String>;
 
 impl<'b, D> Iterator for &'b mut DBIterator<D> {
     type Item = Kv;
 
     fn next(&mut self) -> Option<Kv> {
-        let kv = self.kv();
-        if kv.is_some() {
-            DBIterator::next(self);
+        match self.kv() {
+            Ok(Some(kv)) => {
+                let _ = DBIterator::next(self);
+                Some(Ok(kv))
+            }
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
         }
-        kv
     }
 }
 
@@ -2778,8 +2785,8 @@ mod test {
         db.put(b"k2", b"v2222").expect("");
         db.put(b"k3", b"v3333").expect("");
         let mut iter = db.iter();
-        iter.seek(SeekKey::Start);
-        for (k, v) in &mut iter {
+        iter.seek(SeekKey::Start).unwrap();
+        for (k, v) in iter.map(|res| res.unwrap()) {
             println!(
                 "Hello {}: {}",
                 str::from_utf8(&*k).unwrap(),

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -299,6 +299,7 @@ impl<D> DBIterator<D> {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn kv(&self) -> Result<Option<(Vec<u8>, Vec<u8>)>, String> {
         match self.valid() {
             Ok(true) => Ok(Some((self.key().to_vec(), self.value().to_vec()))),
@@ -315,7 +316,7 @@ impl<D> DBIterator<D> {
         Ok(valid)
     }
 
-    pub fn status(&self) -> Result<(), String> {
+    fn status(&self) -> Result<(), String> {
         unsafe {
             ffi_try!(crocksdb_iter_get_error(self.inner));
         }

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -299,13 +299,17 @@ impl<D> DBIterator<D> {
         }
     }
 
-    #[allow(clippy::type_complexity)]
-    pub fn kv(&self) -> Result<Option<(Vec<u8>, Vec<u8>)>, String> {
+    pub fn kv(&self) -> Result<Option<Kv>, String> {
         match self.valid() {
             Ok(true) => Ok(Some((self.key().to_vec(), self.value().to_vec()))),
             Ok(false) => Ok(None),
             Err(e) => Err(e),
         }
+    }
+
+    /// Similar with `kv`, but must be called when `self.valid() == Ok(true)`.
+    pub fn must_kv(&self) -> Kv {
+        (self.key().to_vec(), self.value().to_vec())
     }
 
     pub fn valid(&self) -> Result<bool, String> {
@@ -324,12 +328,12 @@ impl<D> DBIterator<D> {
     }
 }
 
-pub type Kv = Result<(Vec<u8>, Vec<u8>), String>;
+pub type Kv = (Vec<u8>, Vec<u8>);
 
 impl<'b, D> Iterator for &'b mut DBIterator<D> {
-    type Item = Kv;
+    type Item = Result<Kv, String>;
 
-    fn next(&mut self) -> Option<Kv> {
+    fn next(&mut self) -> Option<Self::Item> {
         match self.kv() {
             Ok(Some(kv)) => {
                 let _ = DBIterator::next(self);

--- a/tests/cases/test_delete_files_in_range.rs
+++ b/tests/cases/test_delete_files_in_range.rs
@@ -66,9 +66,9 @@ fn test_delete_files_in_range_with_iter() {
     db.delete_files_in_range(b"key2", b"key7", false).unwrap();
 
     let mut count = 0;
-    assert!(iter.seek(SeekKey::Start));
-    while iter.valid() {
-        iter.next();
+    assert!(iter.seek(SeekKey::Start).unwrap());
+    while iter.valid().unwrap() {
+        iter.next().unwrap();
         count = count + 1;
     }
 
@@ -89,11 +89,11 @@ fn test_delete_files_in_range_with_snap() {
     db.delete_files_in_range(b"key2", b"key7", false).unwrap();
 
     let mut iter = snap.iter();
-    assert!(iter.seek(SeekKey::Start));
+    assert!(iter.seek(SeekKey::Start).unwrap());
 
     let mut count = 0;
-    while iter.valid() {
-        iter.next();
+    while iter.valid().unwrap() {
+        iter.next().unwrap();
         count = count + 1;
     }
 
@@ -159,12 +159,12 @@ fn test_delete_files_in_range_with_delete_range() {
     db.compact_range(None, None);
 
     let mut it = db.iter();
-    it.seek(SeekKey::Start);
-    assert!(it.valid());
+    it.seek(SeekKey::Start).unwrap();
+    assert!(it.valid().unwrap());
     assert_eq!(it.key(), b"4");
-    assert!(it.next());
+    assert!(it.next().unwrap());
     assert_eq!(it.key(), b"5");
-    assert!(!it.next());
+    assert!(!it.next().unwrap());
 }
 
 #[test]
@@ -186,19 +186,18 @@ fn test_delete_files_in_ranges() {
 
     // Check that ["key0", "key5"] have been deleted, but ["key6", "key8"] still exist.
     let mut iter = db.iter();
-    iter.seek(SeekKey::Start);
+    iter.seek(SeekKey::Start).unwrap();
     for i in 6..9 {
-        assert!(iter.valid());
+        assert!(iter.valid().unwrap());
         let k = format!("key{}", i);
         assert_eq!(iter.key(), k.as_bytes());
-        iter.next();
+        iter.next().unwrap();
     }
-    assert!(!iter.valid());
+    assert!(!iter.valid().unwrap());
 
     // Delete the last file.
     let ranges = vec![Range::new(b"key6", b"key8")];
     db.delete_files_in_ranges_cf(cf, &ranges, true).unwrap();
     let mut iter = db.iter();
-    iter.seek(SeekKey::Start);
-    assert!(!iter.valid());
+    assert!(!iter.seek(SeekKey::Start).unwrap());
 }

--- a/tests/cases/test_delete_range.rs
+++ b/tests/cases/test_delete_range.rs
@@ -44,10 +44,10 @@ fn gen_sst_from_db(opt: ColumnFamilyOptions, cf: Option<&CFHandle>, path: &str, 
     };
     writer.open(path).unwrap();
     let mut iter = db.iter();
-    iter.seek(SeekKey::Start);
-    while iter.valid() {
+    iter.seek(SeekKey::Start).unwrap();
+    while iter.valid().unwrap() {
         writer.put(iter.key(), iter.value()).unwrap();
-        iter.next();
+        iter.next().unwrap();
     }
     writer.finish().unwrap();
 }
@@ -55,11 +55,11 @@ fn gen_sst_from_db(opt: ColumnFamilyOptions, cf: Option<&CFHandle>, path: &str, 
 fn gen_crc32_from_db(db: &DB) -> u32 {
     let mut digest = Digest::new(crc32::IEEE);
     let mut iter = db.iter();
-    iter.seek(SeekKey::Start);
-    while iter.valid() {
+    iter.seek(SeekKey::Start).unwrap();
+    while iter.valid().unwrap() {
         digest.write(iter.key());
         digest.write(iter.value());
-        iter.next();
+        iter.next().unwrap();
     }
     digest.sum32()
 }
@@ -67,14 +67,14 @@ fn gen_crc32_from_db(db: &DB) -> u32 {
 fn gen_crc32_from_db_in_range(db: &DB, start_key: &[u8], end_key: &[u8]) -> u32 {
     let mut digest = Digest::new(crc32::IEEE);
     let mut iter = db.iter();
-    iter.seek(SeekKey::Key(start_key));
-    while iter.valid() {
+    iter.seek(SeekKey::Key(start_key)).unwrap();
+    while iter.valid().unwrap() {
         if iter.key() >= end_key {
             break;
         }
         digest.write(iter.key());
         digest.write(iter.value());
-        iter.next();
+        iter.next().unwrap();
     }
     digest.sum32()
 }

--- a/tests/cases/test_ingest_external_file.rs
+++ b/tests/cases/test_ingest_external_file.rs
@@ -282,16 +282,16 @@ fn gen_sst_from_cf(opt: ColumnFamilyOptions, db: &DB, cf: &CFHandle, path: &str)
     let mut writer = SstFileWriter::new_cf(env_opt, opt, cf);
     writer.open(path).unwrap();
     let mut iter = db.iter_cf(cf);
-    iter.seek(SeekKey::Start);
-    while iter.valid() {
+    iter.seek(SeekKey::Start).unwrap();
+    while iter.valid().unwrap() {
         writer.put(iter.key(), iter.value()).unwrap();
-        iter.next();
+        iter.next().unwrap();
     }
     let info = writer.finish().unwrap();
     assert_eq!(info.file_path().to_str().unwrap(), path);
-    iter.seek(SeekKey::Start);
+    iter.seek(SeekKey::Start).unwrap();
     assert_eq!(info.smallest_key(), iter.key());
-    iter.seek(SeekKey::End);
+    iter.seek(SeekKey::End).unwrap();
     assert_eq!(info.largest_key(), iter.key());
     assert_eq!(info.sequence_number(), 0);
     assert!(info.file_size() > 0);
@@ -522,9 +522,9 @@ fn test_read_sst() {
         assert_eq!(props.num_entries(), 3);
     });
     let mut it = reader.iter();
-    it.seek(SeekKey::Start);
+    it.seek(SeekKey::Start).unwrap();
     assert_eq!(
-        it.collect::<Vec<_>>(),
+        it.map(|res| res.unwrap()).collect::<Vec<_>>(),
         vec![
             (b"k1".to_vec(), b"a".to_vec()),
             (b"k2".to_vec(), b"b".to_vec()),

--- a/tests/cases/test_ingest_external_file.rs
+++ b/tests/cases/test_ingest_external_file.rs
@@ -524,7 +524,7 @@ fn test_read_sst() {
     let mut it = reader.iter();
     it.seek(SeekKey::Start).unwrap();
     assert_eq!(
-        it.map(|res| res.unwrap()).collect::<Vec<_>>(),
+        it.collect::<Vec<_>>(),
         vec![
             (b"k1".to_vec(), b"a".to_vec()),
             (b"k2".to_vec(), b"b".to_vec()),

--- a/tests/cases/test_iterator.rs
+++ b/tests/cases/test_iterator.rs
@@ -48,20 +48,20 @@ impl SliceTransform for FixedSuffixTransform {
     }
 }
 
-fn prev_collect<D: Deref<Target = DB>>(iter: &mut DBIterator<D>) -> Vec<Kv> {
+fn prev_collect<D: Deref<Target = DB>>(iter: &mut DBIterator<D>) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut buf = vec![];
-    while iter.valid() {
-        buf.push(iter.kv().unwrap());
-        iter.prev();
+    while iter.valid().unwrap() {
+        buf.push(iter.kv().unwrap().unwrap());
+        iter.prev().unwrap();
     }
     buf
 }
 
-fn next_collect<D: Deref<Target = DB>>(iter: &mut DBIterator<D>) -> Vec<Kv> {
+fn next_collect<D: Deref<Target = DB>>(iter: &mut DBIterator<D>) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut buf = vec![];
-    while iter.valid() {
-        buf.push(iter.kv().unwrap());
-        iter.next();
+    while iter.valid().unwrap() {
+        buf.push(iter.kv().unwrap().unwrap());
+        iter.next().unwrap();
     }
     buf
 }
@@ -93,33 +93,33 @@ pub fn test_iterator() {
 
     let mut iter = db.iter();
 
-    iter.seek(SeekKey::Start);
-    assert_eq!(iter.collect::<Vec<_>>(), expected);
+    iter.seek(SeekKey::Start).unwrap();
+    assert_eq!(iter.map(|res| res.unwrap()).collect::<Vec<_>>(), expected);
 
     // Test that it's idempotent
-    iter.seek(SeekKey::Start);
-    assert_eq!(iter.collect::<Vec<_>>(), expected);
+    iter.seek(SeekKey::Start).unwrap();
+    assert_eq!(iter.map(|res| res.unwrap()).collect::<Vec<_>>(), expected);
 
     // Test it in reverse a few times
-    iter.seek(SeekKey::End);
+    iter.seek(SeekKey::End).unwrap();
     let mut tmp_vec = prev_collect(&mut iter);
     tmp_vec.reverse();
     assert_eq!(tmp_vec, expected);
 
-    iter.seek(SeekKey::End);
+    iter.seek(SeekKey::End).unwrap();
     let mut tmp_vec = prev_collect(&mut iter);
     tmp_vec.reverse();
     assert_eq!(tmp_vec, expected);
 
     // Try it forward again
-    iter.seek(SeekKey::Start);
-    assert_eq!(iter.collect::<Vec<_>>(), expected);
+    iter.seek(SeekKey::Start).unwrap();
+    assert_eq!(iter.map(|res| res.unwrap()).collect::<Vec<_>>(), expected);
 
-    iter.seek(SeekKey::Start);
-    assert_eq!(iter.collect::<Vec<_>>(), expected);
+    iter.seek(SeekKey::Start).unwrap();
+    assert_eq!(iter.map(|res| res.unwrap()).collect::<Vec<_>>(), expected);
 
     let mut old_iterator = db.iter();
-    old_iterator.seek(SeekKey::Start);
+    old_iterator.seek(SeekKey::Start).unwrap();
     let p = db.put(&*k4, &*v4);
     assert!(p.is_ok());
     let expected2 = vec![
@@ -128,49 +128,40 @@ pub fn test_iterator() {
         (k3.to_vec(), v3.to_vec()),
         (k4.to_vec(), v4.to_vec()),
     ];
-    assert_eq!(old_iterator.collect::<Vec<_>>(), expected);
+    assert_eq!(
+        old_iterator.map(|res| res.unwrap()).collect::<Vec<_>>(),
+        expected
+    );
 
     iter = db.iter();
-    iter.seek(SeekKey::Start);
-    assert_eq!(iter.collect::<Vec<_>>(), expected2);
+    iter.seek(SeekKey::Start).unwrap();
+    assert_eq!(iter.map(|res| res.unwrap()).collect::<Vec<_>>(), expected2);
 
-    iter.seek(SeekKey::Key(k2));
+    iter.seek(SeekKey::Key(k2)).unwrap();
     let expected = vec![
         (k2.to_vec(), v2.to_vec()),
         (k3.to_vec(), v3.to_vec()),
         (k4.to_vec(), v4.to_vec()),
     ];
-    assert_eq!(iter.collect::<Vec<_>>(), expected);
+    assert_eq!(iter.map(|res| res.unwrap()).collect::<Vec<_>>(), expected);
 
-    iter.seek(SeekKey::Key(k2));
+    iter.seek(SeekKey::Key(k2)).unwrap();
     let expected = vec![(k2.to_vec(), v2.to_vec()), (k1.to_vec(), v1.to_vec())];
     assert_eq!(prev_collect(&mut iter), expected);
 
-    iter.seek(SeekKey::Key(b"k0"));
-    assert!(iter.valid());
-    iter.seek(SeekKey::Key(b"k1"));
-    assert!(iter.valid());
-    iter.seek(SeekKey::Key(b"k11"));
-    assert!(iter.valid());
-    iter.seek(SeekKey::Key(b"k5"));
-    assert!(!iter.valid());
-    iter.seek(SeekKey::Key(b"k0"));
-    assert!(iter.valid());
-    iter.seek(SeekKey::Key(b"k1"));
-    assert!(iter.valid());
-    iter.seek(SeekKey::Key(b"k11"));
-    assert!(iter.valid());
-    iter.seek(SeekKey::Key(b"k5"));
-    assert!(!iter.valid());
+    assert!(iter.seek(SeekKey::Key(b"k0")).unwrap());
+    assert!(iter.seek(SeekKey::Key(b"k1")).unwrap());
+    assert!(iter.seek(SeekKey::Key(b"k11")).unwrap());
+    assert!(!iter.seek(SeekKey::Key(b"k5")).unwrap());
+    assert!(iter.seek(SeekKey::Key(b"k0")).unwrap());
+    assert!(iter.seek(SeekKey::Key(b"k1")).unwrap());
+    assert!(iter.seek(SeekKey::Key(b"k11")).unwrap());
+    assert!(!iter.seek(SeekKey::Key(b"k5")).unwrap());
 
-    iter.seek(SeekKey::Key(b"k4"));
-    assert!(iter.valid());
-    iter.prev();
-    assert!(iter.valid());
-    iter.next();
-    assert!(iter.valid());
-    iter.next();
-    assert!(!iter.valid());
+    assert!(iter.seek(SeekKey::Key(b"k4")).unwrap());
+    assert!(iter.prev().unwrap());
+    assert!(iter.next().unwrap());
+    assert!(!iter.next().unwrap());
     // Once iterator is invalid, it can't be reverted.
     //iter.prev();
     //assert!(!iter.valid());
@@ -190,7 +181,7 @@ fn test_send_iterator() {
         let (tx, rx) = mpsc::channel();
         let j = thread::spawn(move || {
             rx.recv().unwrap();
-            iter.seek(SeekKey::Start);
+            iter.seek(SeekKey::Start).unwrap();
             assert_eq!(iter.key(), b"k1");
             assert_eq!(iter.value(), b"v1");
         });
@@ -232,36 +223,36 @@ fn test_seek_for_prev() {
         db.put_opt(b"k1-3", b"d", &writeopts).unwrap();
 
         let mut iter = db.iter();
-        iter.seek_for_prev(SeekKey::Key(b"k1-2"));
-        assert!(iter.valid());
+        iter.seek_for_prev(SeekKey::Key(b"k1-2")).unwrap();
+        assert!(iter.valid().unwrap());
         assert_eq!(iter.key(), b"k1-1");
         assert_eq!(iter.value(), b"b");
 
         let mut iter = db.iter();
-        iter.seek_for_prev(SeekKey::Key(b"k1-3"));
-        assert!(iter.valid());
+        iter.seek_for_prev(SeekKey::Key(b"k1-3")).unwrap();
+        assert!(iter.valid().unwrap());
         assert_eq!(iter.key(), b"k1-3");
         assert_eq!(iter.value(), b"d");
 
         let mut iter = db.iter();
-        iter.seek_for_prev(SeekKey::Start);
-        assert!(iter.valid());
+        iter.seek_for_prev(SeekKey::Start).unwrap();
+        assert!(iter.valid().unwrap());
         assert_eq!(iter.key(), b"k1-0");
         assert_eq!(iter.value(), b"a");
 
         let mut iter = db.iter();
-        iter.seek_for_prev(SeekKey::End);
-        assert!(iter.valid());
+        iter.seek_for_prev(SeekKey::End).unwrap();
+        assert!(iter.valid().unwrap());
         assert_eq!(iter.key(), b"k1-3");
         assert_eq!(iter.value(), b"d");
 
         let mut iter = db.iter();
-        iter.seek_for_prev(SeekKey::Key(b"k0-0"));
-        assert!(!iter.valid());
+        iter.seek_for_prev(SeekKey::Key(b"k0-0")).unwrap();
+        assert!(!iter.valid().unwrap());
 
         let mut iter = db.iter();
-        iter.seek_for_prev(SeekKey::Key(b"k2-0"));
-        assert!(iter.valid());
+        iter.seek_for_prev(SeekKey::Key(b"k2-0")).unwrap();
+        assert!(iter.valid().unwrap());
         assert_eq!(iter.key(), b"k1-3");
         assert_eq!(iter.value(), b"d");
     }
@@ -284,7 +275,7 @@ fn read_with_upper_bound() {
         readopts.set_iterate_upper_bound(upper_bound);
         assert_eq!(readopts.iterate_upper_bound(), b"k2");
         let mut iter = db.iter_opt(readopts);
-        iter.seek(SeekKey::Start);
+        iter.seek(SeekKey::Start).unwrap();
         let vec = next_collect(&mut iter);
         assert_eq!(vec.len(), 2);
     }
@@ -342,12 +333,12 @@ fn test_total_order_seek() {
     let mut iter = db.iter_opt(ropts);
     // only iterate sst files and memtables that contain keys with the same prefix as b"k1"
     // and the keys is iterated as valid when prefixed as b"k1"
-    iter.seek(SeekKey::Key(b"k1-0"));
+    iter.seek(SeekKey::Key(b"k1-0")).unwrap();
     let mut key_count = 0;
-    while iter.valid() {
+    while iter.valid().unwrap() {
         assert_eq!(keys[key_count], iter.key());
         key_count = key_count + 1;
-        iter.next();
+        iter.next().unwrap();
     }
     assert!(key_count == 3);
 
@@ -355,25 +346,25 @@ fn test_total_order_seek() {
     // only iterate sst files and memtables that contain keys with the same prefix as b"k1"
     // but it still can next/prev to the keys which is not prefixed as b"k1" with
     // prefix_same_as_start
-    iter.seek(SeekKey::Key(b"k1-0"));
+    iter.seek(SeekKey::Key(b"k1-0")).unwrap();
     let mut key_count = 0;
-    while iter.valid() {
+    while iter.valid().unwrap() {
         assert_eq!(keys[key_count], iter.key());
         key_count = key_count + 1;
-        iter.next();
+        iter.next().unwrap();
     }
     assert!(key_count == 4);
 
     let mut ropts = ReadOptions::new();
     ropts.set_total_order_seek(true);
     let mut iter = db.iter_opt(ropts);
-    iter.seek(SeekKey::Key(b"k1-0"));
+    iter.seek(SeekKey::Key(b"k1-0")).unwrap();
     let mut key_count = 0;
-    while iter.valid() {
+    while iter.valid().unwrap() {
         // iterator all sst files and memtables
         assert_eq!(keys[key_count], iter.key());
         key_count = key_count + 1;
-        iter.next();
+        iter.next().unwrap();
     }
     assert!(key_count == 9);
 }
@@ -407,12 +398,12 @@ fn test_fixed_suffix_seek() {
     db.flush(true).unwrap();
 
     let mut iter = db.iter();
-    iter.seek(SeekKey::Key(b"k-24yfae-8"));
+    iter.seek(SeekKey::Key(b"k-24yfae-8")).unwrap();
     let vec = prev_collect(&mut iter);
     assert!(vec.len() == 2);
 
     let mut iter = db.iter();
-    iter.seek(SeekKey::Key(b"k-24yfa-9"));
+    iter.seek(SeekKey::Key(b"k-24yfa-9")).unwrap();
     let vec = prev_collect(&mut iter);
     assert!(vec.len() == 0);
 }

--- a/tests/cases/test_prefix_extractor.rs
+++ b/tests/cases/test_prefix_extractor.rs
@@ -87,13 +87,13 @@ fn test_prefix_extractor_compatibility() {
         db.put_opt(b"k1-8", b"c", &wopts).unwrap();
 
         let mut iter = db.iter();
-        iter.seek(SeekKey::Key(b"k1-0"));
+        iter.seek(SeekKey::Key(b"k1-0")).unwrap();
         let mut key_count = 0;
-        while iter.valid() {
+        while iter.valid().unwrap() {
             // If sst file has no prefix bloom, don't use prefix seek model.
             assert_eq!(keys[key_count], iter.key());
             key_count = key_count + 1;
-            iter.next();
+            iter.next().unwrap();
         }
         assert!(key_count == 9);
     }

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -703,12 +703,12 @@ fn test_read_options() {
 
     let keys = vec![b"k1", b"k2", b"k3"];
     let mut iter = db.iter_opt(read_opts);
-    iter.seek(SeekKey::Key(b"k1"));
+    iter.seek(SeekKey::Key(b"k1")).unwrap();
     let mut key_count = 0;
-    while iter.valid() {
+    while iter.valid().unwrap() {
         assert_eq!(keys[key_count], iter.key());
         key_count = key_count + 1;
-        iter.next();
+        iter.next().unwrap();
     }
     assert!(key_count == 3);
 }
@@ -726,11 +726,11 @@ fn test_readoptions_lower_bound() {
     let lower_bound = b"k2".to_vec();
     read_opts.set_iterate_lower_bound(lower_bound);
     let mut iter = db.iter_opt(read_opts);
-    iter.seek(SeekKey::Key(b"k3"));
+    iter.seek(SeekKey::Key(b"k3")).unwrap();
     let mut count = 0;
-    while iter.valid() {
+    while iter.valid().unwrap() {
         count += 1;
-        iter.prev();
+        iter.prev().unwrap();
     }
     assert_eq!(count, 2);
 }
@@ -807,15 +807,15 @@ fn test_vector_memtable_factory_options() {
     db.flush(true).unwrap();
 
     let mut iter = db.iter();
-    iter.seek(SeekKey::Start);
-    assert!(iter.valid());
+    iter.seek(SeekKey::Start).unwrap();
+    assert!(iter.valid().unwrap());
     assert_eq!(iter.key(), b"k1");
     assert_eq!(iter.value(), b"v1");
-    assert!(iter.next());
+    assert!(iter.next().unwrap());
     assert_eq!(iter.key(), b"k2");
     assert_eq!(iter.value(), b"v2");
-    assert!(!iter.next());
-    assert!(!iter.valid());
+    assert!(!iter.next().unwrap());
+    assert!(!iter.valid().unwrap());
 }
 
 #[test]

--- a/tests/cases/test_slice_transform.rs
+++ b/tests/cases/test_slice_transform.rs
@@ -78,8 +78,8 @@ fn test_slice_transform() {
     ];
 
     for key in invalid_seeks {
-        it.seek(SeekKey::Key(&key));
-        assert!(!it.valid());
+        it.seek(SeekKey::Key(&key)).unwrap();
+        assert!(!it.valid().unwrap());
     }
 
     let valid_seeks = vec![
@@ -89,8 +89,8 @@ fn test_slice_transform() {
     ];
 
     for (key, expect_key) in valid_seeks {
-        it.seek(SeekKey::Key(&key));
-        assert!(it.valid());
+        it.seek(SeekKey::Key(&key)).unwrap();
+        assert!(it.valid().unwrap());
         assert_eq!(it.key(), &*expect_key);
     }
 

--- a/tests/cases/test_table_properties.rs
+++ b/tests/cases/test_table_properties.rs
@@ -283,7 +283,7 @@ fn test_table_properties_with_table_filter() {
     let mut iter = db.iter_opt(ropts);
     let key = b"key";
     let key5 = b"key5";
-    assert!(iter.seek(SeekKey::from(key.as_ref())));
+    assert!(iter.seek(SeekKey::from(key.as_ref())).unwrap());
     // First sst will be skipped
     assert_eq!(iter.key(), key5.as_ref());
 }

--- a/tests/cases/test_titan.rs
+++ b/tests/cases/test_titan.rs
@@ -147,31 +147,31 @@ fn test_titandb() {
     assert_eq!(db.get_options_cf(cf1).get_num_levels(), 4);
 
     let mut iter = db.iter();
-    iter.seek(SeekKey::Start);
+    iter.seek(SeekKey::Start).unwrap();
     for i in 0..n {
         for j in 0..n {
             let k = (i * n + j) as u8;
             let v = vec![k; (j + 1) as usize];
             assert_eq!(db.get(&[k]).unwrap().unwrap(), &v);
-            assert!(iter.valid());
+            assert!(iter.valid().unwrap());
             assert_eq!(iter.key(), &[k]);
             assert_eq!(iter.value(), v.as_slice());
-            iter.next();
+            iter.next().unwrap();
         }
     }
 
     let mut readopts = ReadOptions::new();
     readopts.set_titan_key_only(true);
     iter = db.iter_opt(readopts);
-    iter.seek(SeekKey::Start);
+    iter.seek(SeekKey::Start).unwrap();
     for i in 0..n {
         for j in 0..n {
             let k = (i * n + j) as u8;
             let v = vec![k; (j + 1) as usize];
             assert_eq!(db.get(&[k]).unwrap().unwrap(), &v);
-            assert!(iter.valid());
+            assert!(iter.valid().unwrap());
             assert_eq!(iter.key(), &[k]);
-            iter.next();
+            iter.next().unwrap();
         }
     }
 
@@ -179,15 +179,15 @@ fn test_titandb() {
     readopts = ReadOptions::new();
     readopts.set_titan_key_only(true);
     iter = db.iter_cf_opt(&cf_handle, readopts);
-    iter.seek(SeekKey::Start);
+    iter.seek(SeekKey::Start).unwrap();
     for i in 0..n {
         for j in 0..n {
             let k = (i * n + j) as u8;
             let v = vec![k; (j + 1) as usize];
             assert_eq!(db.get(&[k]).unwrap().unwrap(), &v);
-            assert!(iter.valid());
+            assert!(iter.valid().unwrap());
             assert_eq!(iter.key(), &[k]);
-            iter.next();
+            iter.next().unwrap();
         }
     }
 
@@ -292,22 +292,22 @@ fn test_titan_delete_files_in_ranges() {
     let mut readopts = ReadOptions::new();
     readopts.set_titan_key_only(true);
     let mut iter = db.iter_cf_opt(&cf_handle, readopts);
-    iter.seek(SeekKey::Start);
+    iter.seek(SeekKey::Start).unwrap();
     for i in 6..9 {
-        assert!(iter.valid());
+        assert!(iter.valid().unwrap());
         let k = format!("key{}", i);
         assert_eq!(iter.key(), k.as_bytes());
-        iter.next();
+        iter.next().unwrap();
     }
-    assert!(!iter.valid());
+    assert!(!iter.valid().unwrap());
 
     // Delete the last file.
     let ranges = vec![Range::new(b"key6", b"key8")];
     db.delete_files_in_ranges_cf(cf_handle, &ranges, true)
         .unwrap();
     let mut iter = db.iter();
-    iter.seek(SeekKey::Start);
-    assert!(!iter.valid());
+    iter.seek(SeekKey::Start).unwrap();
+    assert!(!iter.valid().unwrap());
 }
 
 #[test]


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

This PR changes some method signatures of `DBIterator`: return `Result` instead of `bool` for `valid`, and all its callers.