### PR TITLE
Travis mac build with xcode11.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rust:
 matrix:
   include:
   - os: osx
+    osx_image: xcode11.3
     rust: stable
 
 env:


### PR DESCRIPTION
Update travis to bulid with xcode11.3, to catch compile error unique to clang11. Tested with a version of rocksdb with clang11 compile errors and see the error in travis CI: https://travis-ci.org/tikv/rust-rocksdb/jobs/634612576?utm_medium=notification&utm_source=github_status

Signed-off-by: Yi Wu <yiwu@pingcap.com>