### PR TITLE
add interface set_target_path_id for CompatOptions

### DIFF
--- a/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -2755,6 +2755,12 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn crocksdb_compactoptions_set_target_path_id(
+        arg1: *mut crocksdb_compactoptions_t,
+        arg2: libc::c_int,
+    );
+}
+extern "C" {
     pub fn crocksdb_compactoptions_set_max_subcompactions(
         arg1: *mut crocksdb_compactoptions_t,
         arg2: libc::c_int,

--- a/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -2091,6 +2091,21 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn crocksdb_options_get_db_paths_num(arg1: *mut crocksdb_options_t) -> usize;
+}
+extern "C" {
+    pub fn crocksdb_options_get_db_path(
+        arg1: *mut crocksdb_options_t,
+        index: usize,
+    ) -> *const libc::c_char;
+}
+extern "C" {
+    pub fn crocksdb_options_get_path_target_size(
+        arg1: *mut crocksdb_options_t,
+        index: usize,
+    ) -> u64;
+}
+extern "C" {
     pub fn crocksdb_options_set_db_log_dir(
         arg1: *mut crocksdb_options_t,
         arg2: *const libc::c_char,

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2502,6 +2502,18 @@ void crocksdb_options_set_db_paths(crocksdb_options_t *opt,
   opt->rep.db_paths = db_paths;
 }
 
+size_t crocksdb_options_get_db_paths_num(crocksdb_options_t *opt) {
+  return opt->rep.db_paths.size();
+}
+
+const char* crocksdb_options_get_db_path(crocksdb_options_t* opt, size_t index) {
+  return opt->rep.db_paths[index].path.data();
+}
+
+uint64_t crocksdb_options_get_path_target_size(crocksdb_options_t* opt, size_t index) {
+  return opt->rep.db_paths[index].target_size;
+}
+
 void crocksdb_options_set_db_log_dir(
     crocksdb_options_t* opt, const char* db_log_dir) {
   opt->rep.db_log_dir = db_log_dir;

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3377,6 +3377,11 @@ void crocksdb_compactoptions_set_target_level(crocksdb_compactoptions_t* opt,
   opt->rep.target_level = n;
 }
 
+void crocksdb_compactoptions_set_target_path_id(crocksdb_compactoptions_t* opt,
+                                             int n) {
+  opt->rep.target_path_id = n;
+}
+
 void crocksdb_compactoptions_set_max_subcompactions(
     crocksdb_compactoptions_t* opt,
     int v) {

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1012,6 +1012,13 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_use_fsync(
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_db_paths(crocksdb_options_t *, const char *const *,
                               const size_t *, const uint64_t *, int);
+extern C_ROCKSDB_LIBRARY_API size_t
+crocksdb_options_get_db_paths_num(crocksdb_options_t *);
+extern C_ROCKSDB_LIBRARY_API const char*
+crocksdb_options_get_db_path(crocksdb_options_t *, size_t index);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_options_get_path_target_size(crocksdb_options_t*, size_t index);
+
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_db_log_dir(
     crocksdb_options_t*, const char*);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1343,6 +1343,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_compactoptions_set_change_level(
     crocksdb_compactoptions_t*, unsigned char);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_compactoptions_set_target_level(
     crocksdb_compactoptions_t*, int);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_compactoptions_set_target_path_id(
+    crocksdb_compactoptions_t*, int);
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_compactoptions_set_max_subcompactions(crocksdb_compactoptions_t*, int);
 extern C_ROCKSDB_LIBRARY_API void

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -751,6 +751,9 @@ extern "C" {
         target_size: *const u64,
         num_paths: c_int,
     );
+    pub fn crocksdb_options_get_db_paths_num(options: *mut Options) -> usize;
+    pub fn crocksdb_options_get_db_path(options: *mut Options, idx: size_t) -> *const c_char;
+    pub fn crocksdb_options_get_path_target_size(options: *mut Options, idx: size_t) -> u64;
     pub fn crocksdb_options_set_vector_memtable_factory(options: *mut Options, reserved_bytes: u64);
     pub fn crocksdb_filterpolicy_create_bloom_full(bits_per_key: c_int) -> *mut DBFilterPolicy;
     pub fn crocksdb_filterpolicy_create_bloom(bits_per_key: c_int) -> *mut DBFilterPolicy;

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1212,6 +1212,7 @@ extern "C" {
     );
     pub fn crocksdb_compactoptions_set_change_level(opt: *mut DBCompactOptions, v: bool);
     pub fn crocksdb_compactoptions_set_target_level(opt: *mut DBCompactOptions, v: i32);
+    pub fn crocksdb_compactoptions_set_target_path_id(opt: *mut DBCompactOptions, v: i32);
     pub fn crocksdb_compactoptions_set_max_subcompactions(opt: *mut DBCompactOptions, v: i32);
     pub fn crocksdb_compactoptions_set_bottommost_level_compaction(
         opt: *mut DBCompactOptions,

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -3231,7 +3231,7 @@ mod test {
     fn test_get_db_path_from_option() {
         let mut opts = DBOptions::new();
         opts.create_if_missing(true);
-        let dir = tempdir_with_prefix("_rust_rocksdb_get_approximate_memtable_stats");
+        let dir = tempdir_with_prefix("_rust_rocksdb_get_db_path_from_option");
         let path = dir.path().to_str().unwrap();
         let db = DB::open(opts, path).unwrap();
         let path_num = db.get_db_options().get_db_paths_num();

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -3226,4 +3226,17 @@ mod test {
         let mp = db.get_map_property_cf(cf_handle, "rocksdb.cfstats");
         assert!(mp.is_some());
     }
+
+    #[test]
+    fn test_get_db_path_from_option() {
+        let mut opts = DBOptions::new();
+        opts.create_if_missing(true);
+        let dir = tempdir_with_prefix("_rust_rocksdb_get_approximate_memtable_stats");
+        let path = dir.path().to_str().unwrap();
+        let db = DB::open(opts, path).unwrap();
+        let path_num = db.get_db_options().get_db_paths_num();
+        assert_eq!(1, path_num);
+        let first_path = db.get_db_options().get_db_path(0).unwrap();
+        assert_eq!(path, first_path.as_str());
+    }
 }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1085,7 +1085,7 @@ impl DBOptions {
         }
     }
 
-    pub fn crocksdb_options_get_target_size(&self, idx: usize) -> u64 {
+    pub fn get_path_target_size(&self, idx: usize) -> u64 {
         unsafe { crocksdb_ffi::crocksdb_options_get_path_target_size(self.inner, idx as size_t) }
     }
 

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -558,6 +558,12 @@ impl CompactOptions {
         }
     }
 
+    pub fn set_target_path_id(&mut self, v: i32) {
+        unsafe {
+            crocksdb_ffi::crocksdb_compactoptions_set_target_path_id(self.inner, v);
+        }
+    }
+
     pub fn set_max_subcompactions(&mut self, v: i32) {
         unsafe {
             crocksdb_ffi::crocksdb_compactoptions_set_max_subcompactions(self.inner, v);

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1070,6 +1070,29 @@ impl DBOptions {
         }
     }
 
+    pub fn get_db_paths_num(&self) -> usize {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_get_db_paths_num(self.inner)
+        }
+    }
+
+    pub fn get_db_path(&self, idx: usize) -> Option<String> {
+        unsafe {
+            let ptr = crocksdb_ffi::crocksdb_options_get_db_path(self.inner, idx as size_t);
+            if ptr.is_null() {
+                return None;
+            }
+            let s = CStr::from_ptr(ptr).to_str().unwrap().to_owned();
+            Some(s)
+        }
+    }
+
+    pub fn crocksdb_options_get_target_size(&self, idx: usize) -> u64 {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_get_path_target_size(self.inner, idx as size_t)
+        }
+    }
+
     /// Set paranoid checks. The default value is `true`. We can set it to `false`
     /// to skip manifest checks.
     pub fn set_paranoid_checks(&self, enable: bool) {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1071,9 +1071,7 @@ impl DBOptions {
     }
 
     pub fn get_db_paths_num(&self) -> usize {
-        unsafe {
-            crocksdb_ffi::crocksdb_options_get_db_paths_num(self.inner)
-        }
+        unsafe { crocksdb_ffi::crocksdb_options_get_db_paths_num(self.inner) }
     }
 
     pub fn get_db_path(&self, idx: usize) -> Option<String> {
@@ -1088,9 +1086,7 @@ impl DBOptions {
     }
 
     pub fn crocksdb_options_get_target_size(&self, idx: usize) -> u64 {
-        unsafe {
-            crocksdb_ffi::crocksdb_options_get_path_target_size(self.inner, idx as size_t)
-        }
+        unsafe { crocksdb_ffi::crocksdb_options_get_path_target_size(self.inner, idx as size_t) }
     }
 
     /// Set paranoid checks. The default value is `true`. We can set it to `false`


### PR DESCRIPTION
I add interface `set_target_path_id` for `CompactOptions`. 
`target_path_id` could make user able to choose db path in which the output data of this compaction job store.