### PR TITLE
Revert "implemented !Send for PerfContext struct (#442)"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 
-#![feature(optin_builtin_traits)]
 extern crate core;
 extern crate libc;
 #[macro_use]

--- a/src/perf_context.rs
+++ b/src/perf_context.rs
@@ -57,8 +57,6 @@ pub struct PerfContext {
     inner: *mut DBPerfContext,
 }
 
-impl !Send for PerfContext {}
-
 impl PerfContext {
     pub fn get() -> PerfContext {
         unsafe {


### PR DESCRIPTION
As commentted in https://github.com/tikv/rust-rocksdb/pull/442#issuecomment-595001970, `PerfContext` is naturally `!Send` because it contains a raw pointer.

Reverting #442 makes this crate compile on stable Rust.

![image](https://user-images.githubusercontent.com/17217495/75947377-1fa55880-5edb-11ea-8b20-b9e81ad7ac1a.png)
