### PR TITLE
fix rocksdb branch and update rocksdb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
 	url = https://github.com/tikv/rocksdb.git
+	branch = 6.4.tikv
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan
 	url = https://github.com/tikv/titan.git


### PR DESCRIPTION
Fix rust-rocksdb/master should point to rocksdb/6.4.tikv. Also update rocksdb with the change:
```
979a985cf 2020-03-25 yiwu@pingcap.com     Add counter in perf_context to time cipher time (#158)
```

Signed-off-by: Yi Wu <yiwu@pingcap.com>