### PR TITLE
expose static_libcpp feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ matrix:
     osx_image: xcode11.3
     rust: stable
   - os: linux
-    arch: arm64
-    rust: stable
-  - os: linux
     rust: nightly
     env: FEATURES="encryption,jemalloc,portable,sse"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ encryption = ["librocksdb_sys/encryption"]
 jemalloc = ["librocksdb_sys/jemalloc"]
 portable = ["librocksdb_sys/portable"]
 sse = ["librocksdb_sys/sse"]
+static_libcpp = ["librocksdb_sys/static_libcpp"]
 valgrind = []
 
 [dependencies]

--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -18,13 +18,13 @@ tempfile = "3.1"
 
 [features]
 default = []
-static_libcpp = []
 encryption = ["openssl-sys"]
 jemalloc = ["jemalloc-sys"]
 # portable doesn't require static link, though it's meaningless
 # when not using with static-link right now in this crate.
 portable = ["libtitan_sys/portable"]
 sse = ["libtitan_sys/sse"]
+static_libcpp = []
 
 [build-dependencies]
 cc = "1.0.3"


### PR DESCRIPTION
#463 forget to expose `static_libcpp` feature to top level Cargo.toml. Fixing it.

Signed-off-by: Yi Wu <yiwu@pingcap.com>
