### PR TITLE
Change Logger trait to accept string slice instead of raw pointer

### DIFF
--- a/tests/cases/test_logger.rs
+++ b/tests/cases/test_logger.rs
@@ -1,11 +1,10 @@
 use std::ffi::VaList;
-use std::sync::atomic::*;
-use std::sync::Arc;
-use std::thread;
+use std::sync::{atomic::*, Arc};
 use std::time::Duration;
+use std::{str, thread};
 
 use super::tempdir_with_prefix;
-use libc::c_char;
+
 use rocksdb::{DBInfoLogLevel as InfoLogLevel, DBOptions, Logger, DB};
 
 #[derive(Default, Clone)]
@@ -26,7 +25,7 @@ struct TestLogger {
 }
 
 impl Logger for TestLogger {
-    fn logv(&self, _log_level: InfoLogLevel, _format: *const c_char, _ap: VaList) {
+    fn logv(&self, _log_level: InfoLogLevel, _format: &str, _ap: VaList) {
         self.print.fetch_add(1, Ordering::SeqCst);
     }
 }


### PR DESCRIPTION
Signed-off-by: Wangweizhen <hawking.rei@gmail.com>

UCP https://github.com/tikv/tikv/issues/6496

Fix this error from clippy.

```
this public function dereferences a raw pointer but is not marked `unsafe`
help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref

```