### PR TITLE
logger: remove valist

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -228,7 +228,7 @@ struct crocksdb_logger_impl_t : public Logger {
   void (*destructor_)(void*);
   void (*logv_internal_)(void* logger, int log_level, const char* log);
 
-  void log_help_(void* logger, int log_level,const char* format, va_list ap) {
+  void log_help_(void* logger, int log_level, const char* format, va_list ap) {
     const int kBufferSize = 1024;
     char buffer[kBufferSize];
     vsnprintf(buffer, kBufferSize, format, ap);
@@ -239,7 +239,8 @@ struct crocksdb_logger_impl_t : public Logger {
     log_help_(rep, InfoLogLevel::INFO_LEVEL, format, ap);
   }
 
-  void Logv(const InfoLogLevel log_level, const char* format, va_list ap) override {
+  void Logv(const InfoLogLevel log_level, const char* format,
+            va_list ap) override {
     log_help_(rep, log_level, format, ap);
   }
 

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -226,16 +226,21 @@ struct crocksdb_logger_impl_t : public Logger {
   void* rep;
 
   void (*destructor_)(void*);
-  void (*logv_internal_)(void* logger, int log_level, const char* format,
-                         va_list ap);
+  void (*logv_internal_)(void* logger, int log_level, const char* log);
 
-  void Logv(const char* format, va_list ap) override {
-    logv_internal_(rep, InfoLogLevel::INFO_LEVEL, format, ap);
+  void log_help_(void* logger, int log_level,const char* format, va_list ap) {
+    const int kBufferSize = 1024;
+    char buffer[kBufferSize];
+    vsnprintf(buffer, kBufferSize, format, ap);
+    logv_internal_(rep, log_level, buffer);
   }
 
-  void Logv(const InfoLogLevel log_level, const char* format,
-            va_list ap) override {
-    logv_internal_(rep, log_level, format, ap);
+  void Logv(const char* format, va_list ap) override {
+    log_help_(rep, InfoLogLevel::INFO_LEVEL, format, ap);
+  }
+
+  void Logv(const InfoLogLevel log_level, const char* format, va_list ap) override {
+    log_help_(rep, log_level, format, ap);
   }
 
   virtual ~crocksdb_logger_impl_t() { (*destructor_)(rep); }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -229,7 +229,7 @@ struct crocksdb_logger_impl_t : public Logger {
   void (*logv_internal_)(void* logger, int log_level, const char* log);
 
   void log_help_(void* logger, int log_level, const char* format, va_list ap) {
-    const int kBufferSize = 1024;
+    constexpr int kBufferSize = 1024;
     char buffer[kBufferSize];
     vsnprintf(buffer, kBufferSize, format, ap);
     logv_internal_(rep, log_level, buffer);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -808,7 +808,8 @@ typedef void (*on_external_file_ingested_cb)(
     void*, crocksdb_t*, const crocksdb_externalfileingestioninfo_t*);
 typedef void (*on_background_error_cb)(void*, crocksdb_backgrounderrorreason_t,
                                        crocksdb_status_ptr_t*);
-typedef void (*on_stall_conditions_changed_cb)(void*, const crocksdb_writestallinfo_t*);
+typedef void (*on_stall_conditions_changed_cb)(
+    void*, const crocksdb_writestallinfo_t*);
 typedef void (*crocksdb_logger_logv_cb)(void*, int log_level, const char*);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_eventlistener_t*

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -809,8 +809,7 @@ typedef void (*on_external_file_ingested_cb)(
 typedef void (*on_background_error_cb)(void*, crocksdb_backgrounderrorreason_t,
                                        crocksdb_status_ptr_t*);
 typedef void (*on_stall_conditions_changed_cb)(void*, const crocksdb_writestallinfo_t*);
-typedef void (*crocksdb_logger_logv_cb)(void*, int log_level, const char*,
-                                        va_list);
+typedef void (*crocksdb_logger_logv_cb)(void*, int log_level, const char*);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_eventlistener_t*
 crocksdb_eventlistener_create(

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -19,7 +19,6 @@ extern crate libc;
 extern crate tempfile;
 
 use std::ffi::CStr;
-use std::ffi::VaList;
 use std::fmt;
 
 use libc::{c_char, c_double, c_int, c_uchar, c_void, size_t};
@@ -1715,12 +1714,7 @@ extern "C" {
     pub fn crocksdb_logger_create(
         state: *mut c_void,
         destructor: extern "C" fn(*mut c_void),
-        logv: extern "C" fn(
-            ctx: *mut c_void,
-            log_level: DBInfoLogLevel,
-            format: *const c_char,
-            ap: VaList,
-        ),
+        logv: extern "C" fn(ctx: *mut c_void, log_level: DBInfoLogLevel, log: *const c_char),
     ) -> *mut DBLogger;
     pub fn crocksdb_create_env_logger(fname: *const libc::c_char, env: *mut DBEnv)
         -> *mut DBLogger;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 // FIXME: we should remove this line after we add safe doc to all the unsafe functions
 // see: https://rust-lang.github.io/rust-clippy/master/index.html#missing_safety_doc
 #![allow(clippy::missing_safety_doc)]
-#![feature(c_variadic)]
 
 extern crate core;
 extern crate libc;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -20,7 +20,7 @@ extern "C" fn logv(ctx: *mut c_void, log_level: InfoLogLevel, log: *const c_char
     unsafe {
         let logger = &*(ctx as *mut Box<dyn Logger>);
         let log = CStr::from_ptr(log);
-        logger.logv(log_level, log.to_str().unwrap());
+        logger.logv(log_level, &log.to_string_lossy());
     }
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,11 +3,11 @@
 use crocksdb_ffi;
 use libc::{c_char, c_void};
 use librocksdb_sys::{DBEnv, DBInfoLogLevel as InfoLogLevel, DBLogger};
-use std::ffi::{CStr, CString, VaList};
+use std::ffi::{CStr, CString};
 use std::str;
 
 pub trait Logger: Send + Sync {
-    fn logv(&self, log_level: InfoLogLevel, format: &str, ap: VaList);
+    fn logv(&self, log_level: InfoLogLevel, log: &str);
 }
 
 extern "C" fn destructor(ctx: *mut c_void) {
@@ -16,11 +16,11 @@ extern "C" fn destructor(ctx: *mut c_void) {
     }
 }
 
-extern "C" fn logv(ctx: *mut c_void, log_level: InfoLogLevel, format: *const c_char, ap: VaList) {
+extern "C" fn logv(ctx: *mut c_void, log_level: InfoLogLevel, log: *const c_char) {
     unsafe {
         let logger = &*(ctx as *mut Box<dyn Logger>);
-        let format = CStr::from_ptr(format);
-        logger.logv(log_level, format.to_str().unwrap(), ap);
+        let log = CStr::from_ptr(log);
+        logger.logv(log_level, log.to_str().unwrap());
     }
 }
 

--- a/tests/cases/test_logger.rs
+++ b/tests/cases/test_logger.rs
@@ -1,4 +1,3 @@
-use std::ffi::VaList;
 use std::sync::{atomic::*, Arc};
 use std::time::Duration;
 use std::{str, thread};
@@ -25,7 +24,8 @@ struct TestLogger {
 }
 
 impl Logger for TestLogger {
-    fn logv(&self, _log_level: InfoLogLevel, _format: &str, _ap: VaList) {
+    fn logv(&self, _log_level: InfoLogLevel, log: &str) {
+        assert!(log.len() > 0);
         self.print.fetch_add(1, Ordering::SeqCst);
     }
 }


### PR DESCRIPTION
remove Valist and make logger return the log string instead of ```snprinf``` by client.

Signed-off-by: Wangweizhen <hawking.rei@gmail.com>