### PR TITLE
logger: use larger buffer and fix header level log

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -286,12 +286,12 @@ struct crocksdb_logger_impl_t : public Logger {
   }
 
   void Logv(const char* format, va_list ap) override {
-    log_help_(rep, InfoLogLevel::INFO_LEVEL, format, ap);
+    log_help_(rep, static_cast<int>(InfoLogLevel::HEADER_LEVEL), format, ap);
   }
 
   void Logv(const InfoLogLevel log_level, const char* format,
             va_list ap) override {
-    log_help_(rep, log_level, format, ap);
+    log_help_(rep, static_cast<int>(log_level), format, ap);
   }
 
   virtual ~crocksdb_logger_impl_t() { (*destructor_)(rep); }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -269,15 +269,17 @@ struct crocksdb_logger_impl_t : public Logger {
 
   void log_help_(void* logger, int log_level, const char* format, va_list ap) {
     // Try twice, first with buffer on stack, second with buffer on heap.
-    constexpr size_t kBufferSize = 500;
-    constexpr size_t kLargeBufferSize = 65536;
+    constexpr int kBufferSize = 500;
     char buffer[kBufferSize];
-    int num = vsnprintf(buffer, kBufferSize, format, ap);
+    va_list ap_copy;
+    va_copy(ap_copy, ap);
+    int num = vsnprintf(buffer, kBufferSize, format, ap_copy);
+    va_end(ap_copy);
     if (num < kBufferSize) {
       logv_internal_(rep, log_level, buffer);
     } else {
-      char* large_buffer = new char[kLargeBufferSize];
-      vsnprintf(large_buffer, kLargeBufferSize, format, ap);
+      char* large_buffer = new char[num + 1];
+      vsnprintf(large_buffer, static_cast<size_t>(num) + 1, format, ap);
       logv_internal_(rep, log_level, large_buffer);
       delete[] large_buffer;
     }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -279,7 +279,7 @@ struct crocksdb_logger_impl_t : public Logger {
       char* large_buffer = new char[kLargeBufferSize];
       vsnprintf(large_buffer, kLargeBufferSize, format, ap);
       logv_internal_(rep, log_level, large_buffer);
-      delete large_buffer;
+      delete[] large_buffer;
     }
   }
 


### PR DESCRIPTION
* RocksDB may print large log lines up to 64k. The default 1k buffer for `logv` is too small and truncates rocksdb log. When we detect log line is too long, we allocate a large enough buffer on heap and try again.
* When log level is not specified, defaults to header level.