### PR TITLE
*-sys: use release lz4

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -13,6 +13,7 @@ libtitan_sys = { path = "libtitan_sys" }
 libz-sys = { version = "1.0.25", features = ["static"] }
 openssl-sys = { version = "0.9.54", optional = true, features = ["vendored"] }
 zstd-sys = "1.4.15+zstd.1.4.4"
+lz4-sys = "1.9"
 
 [dev-dependencies]
 tempfile = "3.1"
@@ -37,10 +38,6 @@ bindgen = "0.51"
 version = "0.4.0"
 optional = true
 features = ["unprefixed_malloc_on_supported_platforms"]
-
-[dependencies.lz4-sys]
-git = "https://github.com/busyjay/lz4-rs.git"
-branch = "adjust-build"
 
 [dependencies.snappy-sys]
 git = "https://github.com/busyjay/rust-snappy.git"

--- a/librocksdb_sys/libtitan_sys/Cargo.toml
+++ b/librocksdb_sys/libtitan_sys/Cargo.toml
@@ -9,6 +9,7 @@ bzip2-sys = "0.1.8+1.0.8"
 libc = "0.2.11"
 libz-sys = { version = "1.0.25", features = ["static"] }
 zstd-sys = "1.4.15+zstd.1.4.4"
+lz4-sys = "1.9"
 
 [features]
 default = []
@@ -20,10 +21,6 @@ sse = []
 [build-dependencies]
 cc = "1.0.3"
 cmake = "0.1"
-
-[dependencies.lz4-sys]
-git = "https://github.com/busyjay/lz4-rs.git"
-branch = "adjust-build"
 
 [dependencies.snappy-sys]
 git = "https://github.com/busyjay/rust-snappy.git"


### PR DESCRIPTION
bozaro/lz4-rs#23 is merged and released, we can switch to crates.io now.

This is one step forward for #340.