### PR TITLE
libtitan_sys: upgrade libz-sys's version to 1.1.2

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -10,7 +10,7 @@ bzip2-sys = "0.1.8+1.0.8"
 libc = "0.2.11"
 librocksdb_cloud_sys = { path = "librocksdb_cloud_sys" }
 libtitan_sys = { path = "libtitan_sys" }
-libz-sys = { version = "1.0.25", features = ["static"] }
+libz-sys = { version = "1.1", features = ["static"] }
 openssl-sys = { version = "0.9.54", optional = true, features = ["vendored"] }
 zstd-sys = "1.4.15+zstd.1.4.4"
 lz4-sys = "1.9"

--- a/librocksdb_sys/libtitan_sys/Cargo.toml
+++ b/librocksdb_sys/libtitan_sys/Cargo.toml
@@ -7,7 +7,7 @@ links = "titan"
 [dependencies]
 bzip2-sys = "0.1.8+1.0.8"
 libc = "0.2.11"
-libz-sys = { version = "1.0.25", features = ["static"] }
+libz-sys = { version = "1.1", features = ["static"] }
 zstd-sys = "1.4.15+zstd.1.4.4"
 lz4-sys = "1.9"
 


### PR DESCRIPTION
Signed-off-by: gentcys <iamchencong@gmail.com>

An error occurred while compiling on macOS, which described in https://github.com/tikv/tikv/issues/8659.
And it's fixed by https://github.com/rust-lang/libz-sys/commit/81026e996eb3804acf1e6898a3c1d791cdfb59f1.
This PR just update the version of dependency `libz-sys`.