### PR TITLE
Add option for max-background-flushes and max-background-compactions

### DIFF
--- a/librocksdb_sys/bindings/aarch64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/aarch64-unknown-linux-gnu-bindings.rs
@@ -2064,6 +2064,16 @@ extern "C" {
         -> libc::c_int;
 }
 extern "C" {
+    pub fn crocksdb_options_set_max_background_compactions(
+        arg1: *mut crocksdb_options_t,
+        arg2: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn crocksdb_options_get_max_background_compactions(arg1: *const crocksdb_options_t)
+        -> libc::c_int;
+}
+extern "C" {
     pub fn crocksdb_options_set_max_background_flushes(
         arg1: *mut crocksdb_options_t,
         arg2: libc::c_int,

--- a/librocksdb_sys/bindings/aarch64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/aarch64-unknown-linux-gnu-bindings.rs
@@ -2064,6 +2064,16 @@ extern "C" {
         -> libc::c_int;
 }
 extern "C" {
+    pub fn crocksdb_options_set_max_background_flushes(
+        arg1: *mut crocksdb_options_t,
+        arg2: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn crocksdb_options_get_max_background_flushes(arg1: *const crocksdb_options_t)
+        -> libc::c_int;
+}
+extern "C" {
     pub fn crocksdb_options_set_max_log_file_size(arg1: *mut crocksdb_options_t, arg2: usize);
 }
 extern "C" {

--- a/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -2167,6 +2167,16 @@ extern "C" {
         -> libc::c_int;
 }
 extern "C" {
+    pub fn crocksdb_options_set_max_background_flushes(
+        arg1: *mut crocksdb_options_t,
+        arg2: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn crocksdb_options_get_max_background_flushes(arg1: *const crocksdb_options_t)
+        -> libc::c_int;
+}
+extern "C" {
     pub fn crocksdb_options_set_max_log_file_size(arg1: *mut crocksdb_options_t, arg2: usize);
 }
 extern "C" {

--- a/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -2167,6 +2167,16 @@ extern "C" {
         -> libc::c_int;
 }
 extern "C" {
+    pub fn crocksdb_options_set_max_background_compactions(
+        arg1: *mut crocksdb_options_t,
+        arg2: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn crocksdb_options_get_max_background_compactions(arg1: *const crocksdb_options_t)
+        -> libc::c_int;
+}
+extern "C" {
     pub fn crocksdb_options_set_max_background_flushes(
         arg1: *mut crocksdb_options_t,
         arg2: libc::c_int,

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2817,6 +2817,14 @@ int crocksdb_options_get_max_background_jobs(const crocksdb_options_t* opt) {
   return opt->rep.max_background_jobs;
 }
 
+void crocksdb_options_set_max_background_compactions(crocksdb_options_t* opt, int n) {
+  opt->rep.max_background_compactions = n;
+}
+
+int crocksdb_options_get_max_background_compactions(const crocksdb_options_t* opt) {
+  return opt->rep.max_background_compactions;
+}
+
 void crocksdb_options_set_max_background_flushes(crocksdb_options_t* opt, int n) {
   opt->rep.max_background_flushes = n;
 }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2817,6 +2817,14 @@ int crocksdb_options_get_max_background_jobs(const crocksdb_options_t* opt) {
   return opt->rep.max_background_jobs;
 }
 
+void crocksdb_options_set_max_background_flushes(crocksdb_options_t* opt, int n) {
+  opt->rep.max_background_flushes = n;
+}
+
+int crocksdb_options_get_max_background_flushes(const crocksdb_options_t* opt) {
+  return opt->rep.max_background_flushes;
+}
+
 void crocksdb_options_set_max_log_file_size(crocksdb_options_t* opt, size_t v) {
   opt->rep.max_log_file_size = v;
 }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2817,15 +2817,18 @@ int crocksdb_options_get_max_background_jobs(const crocksdb_options_t* opt) {
   return opt->rep.max_background_jobs;
 }
 
-void crocksdb_options_set_max_background_compactions(crocksdb_options_t* opt, int n) {
+void crocksdb_options_set_max_background_compactions(crocksdb_options_t* opt,
+                                                     int n) {
   opt->rep.max_background_compactions = n;
 }
 
-int crocksdb_options_get_max_background_compactions(const crocksdb_options_t* opt) {
+int crocksdb_options_get_max_background_compactions(
+    const crocksdb_options_t* opt) {
   return opt->rep.max_background_compactions;
 }
 
-void crocksdb_options_set_max_background_flushes(crocksdb_options_t* opt, int n) {
+void crocksdb_options_set_max_background_flushes(crocksdb_options_t* opt,
+                                                 int n) {
   opt->rep.max_background_flushes = n;
 }
 

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1062,6 +1062,10 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_jobs(
     crocksdb_options_t*, int);
 extern C_ROCKSDB_LIBRARY_API int crocksdb_options_get_max_background_jobs(
     const crocksdb_options_t*);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_compactions(
+    crocksdb_options_t*, int);
+extern C_ROCKSDB_LIBRARY_API int crocksdb_options_get_max_background_compactions(
+    const crocksdb_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_flushes(
     crocksdb_options_t*, int);
 extern C_ROCKSDB_LIBRARY_API int crocksdb_options_get_max_background_flushes(

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1062,10 +1062,10 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_jobs(
     crocksdb_options_t*, int);
 extern C_ROCKSDB_LIBRARY_API int crocksdb_options_get_max_background_jobs(
     const crocksdb_options_t*);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_compactions(
-    crocksdb_options_t*, int);
-extern C_ROCKSDB_LIBRARY_API int crocksdb_options_get_max_background_compactions(
-    const crocksdb_options_t*);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_options_set_max_background_compactions(crocksdb_options_t*, int);
+extern C_ROCKSDB_LIBRARY_API int
+crocksdb_options_get_max_background_compactions(const crocksdb_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_flushes(
     crocksdb_options_t*, int);
 extern C_ROCKSDB_LIBRARY_API int crocksdb_options_get_max_background_flushes(

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1062,6 +1062,10 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_jobs(
     crocksdb_options_t*, int);
 extern C_ROCKSDB_LIBRARY_API int crocksdb_options_get_max_background_jobs(
     const crocksdb_options_t*);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_flushes(
+    crocksdb_options_t*, int);
+extern C_ROCKSDB_LIBRARY_API int crocksdb_options_get_max_background_flushes(
+    const crocksdb_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_log_file_size(
     crocksdb_options_t*, size_t);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_log_file_time_to_roll(

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -710,6 +710,11 @@ extern "C" {
     pub fn crocksdb_set_bottommost_compression(options: *mut Options, c: DBCompressionType);
     pub fn crocksdb_options_set_max_background_jobs(options: *mut Options, max_bg_jobs: c_int);
     pub fn crocksdb_options_get_max_background_jobs(options: *const Options) -> c_int;
+    pub fn crocksdb_options_set_max_background_compactions(
+        options: *mut Options,
+        max_bg_compactions: c_int,
+    );
+    pub fn crocksdb_options_get_max_background_compactions(options: *const Options) -> c_int;
     pub fn crocksdb_options_set_max_background_flushes(
         options: *mut Options,
         max_bg_flushes: c_int,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -710,6 +710,11 @@ extern "C" {
     pub fn crocksdb_set_bottommost_compression(options: *mut Options, c: DBCompressionType);
     pub fn crocksdb_options_set_max_background_jobs(options: *mut Options, max_bg_jobs: c_int);
     pub fn crocksdb_options_get_max_background_jobs(options: *const Options) -> c_int;
+    pub fn crocksdb_options_set_max_background_flushes(
+        options: *mut Options,
+        max_bg_flushes: c_int,
+    );
+    pub fn crocksdb_options_get_max_background_flushes(options: *const Options) -> c_int;
     pub fn crocksdb_options_set_disable_auto_compactions(options: *mut Options, v: c_int);
     pub fn crocksdb_options_get_disable_auto_compactions(options: *const Options) -> c_int;
     pub fn crocksdb_options_set_report_bg_io_stats(options: *mut Options, v: c_int);

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -3362,6 +3362,13 @@ mod test {
         let db_opts = db.get_db_options();
         assert_eq!(db_opts.get_max_background_jobs(), 8);
 
+        db.set_db_options(&[("max_background_compactions", "6")]).unwrap();
+        db.set_db_options(&[("max_background_flushes", "3")]).unwrap();
+        let db_opts = db.get_db_options();
+        assert_eq!(db_opts.get_max_background_jobs(), 9);
+        assert_eq!(db_opts.get_max_background_compactions(), 6);
+        assert_eq!(db_opts.get_max_background_flushes(), 3);
+
         let cf_opts = db.get_options_cf(cf);
         assert_eq!(cf_opts.get_disable_auto_compactions(), false);
         db.set_options_cf(cf, &[("disable_auto_compactions", "true")])

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -3365,7 +3365,7 @@ mod test {
         db.set_db_options(&[("max_background_compactions", "6")]).unwrap();
         db.set_db_options(&[("max_background_flushes", "3")]).unwrap();
         let db_opts = db.get_db_options();
-        assert_eq!(db_opts.get_max_background_jobs(), 9);
+        assert_eq!(db_opts.get_max_background_jobs(), 8);
         assert_eq!(db_opts.get_max_background_compactions(), 6);
         assert_eq!(db_opts.get_max_background_flushes(), 3);
 

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -815,6 +815,16 @@ impl DBOptions {
         unsafe { crocksdb_ffi::crocksdb_options_get_max_background_jobs(self.inner) as i32 }
     }
 
+    pub fn set_max_background_compactions(&mut self, n: c_int) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_max_background_compactions(self.inner, n);
+        }
+    }
+
+    pub fn get_max_background_compactions(&self) -> i32 {
+        unsafe { crocksdb_ffi::crocksdb_options_get_max_background_compactions(self.inner) as i32 }
+    }
+
     pub fn set_max_background_flushes(&mut self, n: c_int) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_max_background_flushes(self.inner, n);

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -815,6 +815,16 @@ impl DBOptions {
         unsafe { crocksdb_ffi::crocksdb_options_get_max_background_jobs(self.inner) as i32 }
     }
 
+    pub fn set_max_background_flushes(&mut self, n: c_int) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_max_background_flushes(self.inner, n);
+        }
+    }
+
+    pub fn get_max_background_flushes(&self) -> i32 {
+        unsafe { crocksdb_ffi::crocksdb_options_get_max_background_flushes(self.inner) as i32 }
+    }
+
     pub fn set_max_subcompactions(&mut self, n: u32) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_max_subcompactions(self.inner, n);

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -587,6 +587,16 @@ fn test_set_max_background_jobs() {
 }
 
 #[test]
+fn test_set_max_background_compactions_and_flushes() {
+    let path = tempdir_with_prefix("_rust_rocksdb_max_background_compactions_and_flushes");
+    let mut opts = DBOptions::new();
+    opts.create_if_missing(true);
+    opts.set_max_background_compactions(4);
+    opts.set_max_background_flushes(1);
+    DB::open(opts, path.path().to_str().unwrap()).unwrap();
+}
+
+#[test]
 fn test_set_compaction_pri() {
     let path = tempdir_with_prefix("_rust_rocksdb_compaction_pri");
     let mut opts = DBOptions::new();


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

Add option setter/getter for max-background-flushes and max-background-compactions, they are backward compatible as per https://github.com/facebook/rocksdb/blob/a242a5830116c2fdd476af79873297a7e0d02410/include/rocksdb/options.h#L567.

Depend on tikv/rocksdb#199