### PR TITLE
Add ingest optimization related options 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
-	url = https://github.com/tikv/rocksdb.git
-	branch = 6.4.tikv
+	url = https://github.com/Connor1996/rocksdb.git
+	branch = ingore-ingest
 
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2173,6 +2173,11 @@ crocksdb_externalfileingestioninfo_table_properties(
       &info->rep.table_properties);
 }
 
+int crocksdb_externalfileingestioninfo_picked_level(
+    const crocksdb_externalfileingestioninfo_t* info) {
+  return info->rep.picked_level;
+}
+
 /* External write stall info */
 extern C_ROCKSDB_LIBRARY_API const char* crocksdb_writestallinfo_cf_name(
     const crocksdb_writestallinfo_t* info, size_t* size) {
@@ -2484,6 +2489,11 @@ void crocksdb_options_set_max_bytes_for_level_base(crocksdb_options_t* opt,
 void crocksdb_options_set_level_compaction_dynamic_level_bytes(
     crocksdb_options_t* opt, unsigned char v) {
   opt->rep.level_compaction_dynamic_level_bytes = v;
+}
+
+void crocksdb_options_set_ingest_tolerant_ratio(
+    crocksdb_options_t* opt, size_t ratio) {
+  opt->rep.ingest_tolerant_ratio = ratio;
 }
 
 unsigned char crocksdb_options_get_level_compaction_dynamic_level_bytes(
@@ -4278,6 +4288,12 @@ void crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
     crocksdb_ingestexternalfileoptions_t* opt,
     unsigned char allow_blocking_flush) {
   opt->rep.allow_blocking_flush = allow_blocking_flush;
+}
+
+void crocksdb_ingestexternalfileoptions_set_write_global_seqno(
+    crocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char write_global_seqno) {
+  opt->rep.write_global_seqno = write_global_seqno;
 }
 
 void crocksdb_ingestexternalfileoptions_destroy(

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2491,8 +2491,8 @@ void crocksdb_options_set_level_compaction_dynamic_level_bytes(
   opt->rep.level_compaction_dynamic_level_bytes = v;
 }
 
-void crocksdb_options_set_ingest_tolerant_ratio(
-    crocksdb_options_t* opt, size_t ratio) {
+void crocksdb_options_set_ingest_tolerant_ratio(crocksdb_options_t* opt,
+                                                size_t ratio) {
   opt->rep.ingest_tolerant_ratio = ratio;
 }
 

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -842,7 +842,7 @@ crocksdb_externalfileingestioninfo_internal_file_path(
 extern C_ROCKSDB_LIBRARY_API const crocksdb_table_properties_t*
 crocksdb_externalfileingestioninfo_table_properties(
     const crocksdb_externalfileingestioninfo_t*);
-extern C_ROCKSDB_LIBRARY_API int 
+extern C_ROCKSDB_LIBRARY_API int
 crocksdb_externalfileingestioninfo_picked_level(
     const crocksdb_externalfileingestioninfo_t*);
 
@@ -1013,9 +1013,8 @@ crocksdb_options_set_optimize_filters_for_hits(crocksdb_options_t*,
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_level_compaction_dynamic_level_bytes(crocksdb_options_t*,
                                                           unsigned char);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_options_set_ingest_tolerant_ratio(crocksdb_options_t*,
-                                                         size_t);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_ingest_tolerant_ratio(
+    crocksdb_options_t*, size_t);
 extern C_ROCKSDB_LIBRARY_API unsigned char
 crocksdb_options_get_level_compaction_dynamic_level_bytes(
     const crocksdb_options_t* const options);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -842,6 +842,9 @@ crocksdb_externalfileingestioninfo_internal_file_path(
 extern C_ROCKSDB_LIBRARY_API const crocksdb_table_properties_t*
 crocksdb_externalfileingestioninfo_table_properties(
     const crocksdb_externalfileingestioninfo_t*);
+extern C_ROCKSDB_LIBRARY_API int 
+crocksdb_externalfileingestioninfo_picked_level(
+    const crocksdb_externalfileingestioninfo_t*);
 
 /* External write stall info */
 extern C_ROCKSDB_LIBRARY_API const char* crocksdb_writestallinfo_cf_name(
@@ -1010,6 +1013,9 @@ crocksdb_options_set_optimize_filters_for_hits(crocksdb_options_t*,
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_level_compaction_dynamic_level_bytes(crocksdb_options_t*,
                                                           unsigned char);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_options_set_ingest_tolerant_ratio(crocksdb_options_t*,
+                                                         size_t);
 extern C_ROCKSDB_LIBRARY_API unsigned char
 crocksdb_options_get_level_compaction_dynamic_level_bytes(
     const crocksdb_options_t* const options);
@@ -1730,6 +1736,10 @@ extern C_ROCKSDB_LIBRARY_API void
 crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
     crocksdb_ingestexternalfileoptions_t* opt,
     unsigned char allow_blocking_flush);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_ingestexternalfileoptions_set_write_global_seqno(
+    crocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char write_global_seqno);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_ingestexternalfileoptions_destroy(
     crocksdb_ingestexternalfileoptions_t* opt);
 

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -782,6 +782,7 @@ extern "C" {
         options: *mut Options,
         v: bool,
     );
+    pub fn crocksdb_options_set_ingest_tolerant_ratio(options: *mut Options, v: u64);
     pub fn crocksdb_options_get_level_compaction_dynamic_level_bytes(
         options: *const Options,
     ) -> bool;
@@ -1607,6 +1608,10 @@ extern "C" {
         opt: *mut IngestExternalFileOptions,
         allow_blocking_flush: bool,
     );
+    pub fn crocksdb_ingestexternalfileoptions_set_write_global_seqno(
+        opt: *mut IngestExternalFileOptions,
+        write_global_seqno: bool,
+    );
     pub fn crocksdb_ingestexternalfileoptions_destroy(opt: *mut IngestExternalFileOptions);
 
     // KeyManagedEncryptedEnv
@@ -2116,6 +2121,7 @@ extern "C" {
     pub fn crocksdb_externalfileingestioninfo_table_properties(
         info: *const DBIngestionInfo,
     ) -> *const DBTableProperties;
+    pub fn crocksdb_externalfileingestioninfo_picked_level(info: *const DBIngestionInfo) -> c_int;
 
     pub fn crocksdb_writestallinfo_cf_name(
         info: *const DBWriteStallInfo,

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -153,6 +153,10 @@ impl IngestionInfo {
             TableProperties::from_ptr(prop)
         }
     }
+
+    pub fn picked_level(&self) -> i32 {
+        unsafe { crocksdb_ffi::crocksdb_externalfileingestioninfo_picked_level(&self.0) }
+    }
 }
 
 #[repr(transparent)]

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1567,6 +1567,12 @@ impl ColumnFamilyOptions {
         }
     }
 
+    pub fn set_ingest_tolerant_ratio(&mut self, ratio: u64) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_ingest_tolerant_ratio(self.inner, ratio);
+        }
+    }
+
     pub fn get_level_compaction_dynamic_level_bytes(&self) -> bool {
         unsafe {
             crocksdb_ffi::crocksdb_options_get_level_compaction_dynamic_level_bytes(self.inner)
@@ -2006,6 +2012,16 @@ impl IngestExternalFileOptions {
             crocksdb_ffi::crocksdb_ingestexternalfileoptions_set_move_files(
                 self.inner,
                 whether_move,
+            );
+        }
+    }
+
+    /// Set to true to write global seqno in SST file.
+    pub fn write_global_seqno(&mut self, whether_write: bool) {
+        unsafe {
+            crocksdb_ffi::crocksdb_ingestexternalfileoptions_set_write_global_seqno(
+                self.inner,
+                whether_write,
             );
         }
     }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1975,7 +1975,7 @@ impl IngestExternalFileOptions {
 
     /// If set to false, an ingested file keys could appear in existing snapshots
     /// that where created before the file was ingested.
-    pub fn snapshot_consistent(&mut self, whether_consistent: bool) {
+    pub fn snapshot_consistency(&mut self, whether_consistent: bool) {
         unsafe {
             crocksdb_ffi::crocksdb_ingestexternalfileoptions_set_snapshot_consistency(
                 self.inner,

--- a/tests/cases/test_ingest_external_file.rs
+++ b/tests/cases/test_ingest_external_file.rs
@@ -342,6 +342,8 @@ fn test_ingest_simulate_real_world() {
         let handle = db2.cf_handle(cf).unwrap();
         let mut ingest_opt = IngestExternalFileOptions::new();
         ingest_opt.move_files(true);
+        ingest_opt.snapshot_consistency(false);
+        ingest_opt.write_global_seqno(false);
         db2.ingest_external_file_cf(
             handle,
             &ingest_opt,


### PR DESCRIPTION
This PR does:
- add `picked_level` for `FileIngestionInfo`
- add `write_global_seqno` for `IngestExternalFileOption`
- add `ingest_tolerant_ratio` config