### PR TITLE
expose seqno from compaction filter and iterator 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
-	url = https://github.com/tikv/rocksdb.git
-	branch = 6.4.tikv
+	url = https://github.com/hicqu/rocksdb.git
+	branch = "compaction-filter-seqno"
 
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
-	url = https://github.com/hicqu/rocksdb.git
-	branch = "compaction-filter-seqno"
+	url = https://github.com/tikv/rocksdb.git
+	branch = 6.4.tikv
 
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -104,7 +104,6 @@ using rocksdb::FilterBitsReader;
 using rocksdb::FilterPolicy;
 using rocksdb::FlushJobInfo;
 using rocksdb::FlushOptions;
-using rocksdb::FullKey;
 using rocksdb::HistogramData;
 using rocksdb::InfoLogLevel;
 using rocksdb::IngestExternalFileOptions;
@@ -3534,11 +3533,6 @@ void crocksdb_readoptions_set_ignore_range_deletions(
   opt->rep.ignore_range_deletions = v;
 }
 
-void crocksdb_readoptions_set_iter_start_seqnum(crocksdb_readoptions_t* opt,
-                                                uint64_t v) {
-  opt->rep.iter_start_seqnum = v;
-}
-
 struct TableFilterCtx {
   TableFilterCtx(void* ctx, void (*destroy)(void*))
       : ctx_(ctx), destroy_(destroy) {}
@@ -6437,20 +6431,6 @@ void ctitandb_delete_blob_files_in_ranges_cf(
   }
   SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
                         cf->rep, &ranges[0], num_ranges, include_end));
-}
-
-unsigned char parse_full_key(const char* key, size_t length,
-                             const char** user_key, size_t* user_key_length,
-                             SequenceNumber* seqno, EntryType* entry_type) {
-  FullKey result;
-  if (!ParseFullKey(Slice(key, length), &result)) {
-    return false;
-  }
-  *user_key = result.user_key.data();
-  *user_key_length = result.user_key.size();
-  *seqno = result.sequence;
-  *entry_type = result.type;
-  return true;
 }
 
 /* RocksDB Cloud */

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -392,27 +392,28 @@ struct crocksdb_map_property_t {
 struct crocksdb_compactionfilter_t : public CompactionFilter {
   void* state_;
   void (*destructor_)(void*);
-  Decision (*filter_v2_)(void*, int level, const char* key, size_t key_length,
-                         ValueType value_type, const char* existing_value,
-                         size_t value_length, char** new_value,
-                         size_t* new_value_length, char** skip_until,
-                         size_t* skip_until_length);
+  Decision (*filter_)(void*, int level, const char* key, size_t key_length,
+                      uint64_t seqno, ValueType value_type,
+                      const char* existing_value, size_t value_length,
+                      char** new_value, size_t* new_value_length,
+                      char** skip_until, size_t* skip_until_length);
 
   const char* (*name_)(void*);
 
   virtual ~crocksdb_compactionfilter_t() { (*destructor_)(state_); }
 
-  virtual Decision FilterV2(int level, const Slice& key, ValueType value_type,
-                            const Slice& existing_value, std::string* new_value,
+  virtual Decision FilterV3(int level, const Slice& key, uint64_t seqno,
+                            ValueType value_type, const Slice& existing_value,
+                            std::string* new_value,
                             std::string* skip_until) const override {
     char* c_new_value = nullptr;
     char* c_skip_until = nullptr;
     size_t new_value_length, skip_until_length = 0;
 
-    Decision result = (*filter_v2_)(
-        state_, level, key.data(), key.size(), value_type,
-        existing_value.data(), existing_value.size(), &c_new_value,
-        &new_value_length, &c_skip_until, &skip_until_length);
+    Decision result =
+        (*filter_)(state_, level, key.data(), key.size(), seqno, value_type,
+                   existing_value.data(), existing_value.size(), &c_new_value,
+                   &new_value_length, &c_skip_until, &skip_until_length);
     if (result == Decision::kChangeValue) {
       new_value->assign(c_new_value, new_value_length);
       free(c_new_value);
@@ -3258,10 +3259,10 @@ custom cache
 table_properties_collectors
 */
 
-crocksdb_compactionfilter_t* crocksdb_compactionfilter_create_v2(
+crocksdb_compactionfilter_t* crocksdb_compactionfilter_create(
     void* state, void (*destructor)(void*),
-    CompactionFilter::Decision (*filter_v2)(
-        void*, int level, const char* key, size_t key_length,
+    CompactionFilter::Decision (*filter)(
+        void*, int level, const char* key, size_t key_length, uint64_t seqno,
         CompactionFilter::ValueType value_type, const char* existing_value,
         size_t value_length, char** new_value, size_t* new_value_length,
         char** skip_until, size_t* skip_until_length),
@@ -3269,7 +3270,7 @@ crocksdb_compactionfilter_t* crocksdb_compactionfilter_create_v2(
   crocksdb_compactionfilter_t* result = new crocksdb_compactionfilter_t;
   result->state_ = state;
   result->destructor_ = destructor;
-  result->filter_v2_ = filter_v2;
+  result->filter_ = filter;
   result->name_ = name;
   return result;
 }

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1310,23 +1310,6 @@ crocksdb_ratelimiter_get_bytes_per_second(crocksdb_ratelimiter_t* limiter);
 extern C_ROCKSDB_LIBRARY_API int64_t crocksdb_ratelimiter_get_total_requests(
     crocksdb_ratelimiter_t* limiter, unsigned char pri);
 
-/* Compaction Filter */
-
-extern C_ROCKSDB_LIBRARY_API crocksdb_compactionfilter_t*
-crocksdb_compactionfilter_create(
-    void* state, void (*destructor)(void*),
-    unsigned char (*filter)(void*, int level, const char* key,
-                            size_t key_length, const char* existing_value,
-                            size_t value_length, char** new_value,
-                            size_t* new_value_length,
-                            unsigned char* value_changed),
-    const char* (*name)(void*));
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_compactionfilter_set_ignore_snapshots(crocksdb_compactionfilter_t*,
-                                               unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_compactionfilter_destroy(
-    crocksdb_compactionfilter_t*);
-
 /* Compaction Filter Context */
 
 extern C_ROCKSDB_LIBRARY_API unsigned char

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1516,14 +1516,15 @@ extern "C" {
         propname: *const c_char,
     ) -> *mut c_char;
     // Compaction filter
-    pub fn crocksdb_compactionfilter_create_v2(
+    pub fn crocksdb_compactionfilter_create(
         state: *mut c_void,
         destructor: extern "C" fn(*mut c_void),
-        filter_v2: extern "C" fn(
+        filter: extern "C" fn(
             *mut c_void,
             c_int,
             *const u8,
             size_t,
+            u64,
             CompactionFilterValueType,
             *const u8,
             size_t,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -19,7 +19,7 @@ extern crate libc;
 extern crate tempfile;
 
 use std::ffi::CStr;
-use std::fmt;
+use std::{fmt, ptr, slice};
 
 use libc::{c_char, c_double, c_int, c_uchar, c_void, size_t};
 
@@ -461,6 +461,39 @@ pub enum CompactionFilterDecision {
     Remove = 1,
     ChangeValue = 2,
     RemoveAndSkipUntil = 3,
+}
+
+pub struct FullKey<'a> {
+    pub user_key: &'a [u8],
+    pub sequence: u64,
+    pub entry_type: DBEntryType,
+}
+
+impl<'a> FullKey<'a> {
+    pub fn parse_from_internal(internal_key: &'a [u8]) -> Result<Self, String> {
+        let mut user_key: *const u8 = ptr::null_mut();
+        let mut user_key_length: size_t = 0;
+        let mut sequence = 0;
+        let mut entry_type = DBEntryType::Put;
+        unsafe {
+            let success = parse_full_key(
+                internal_key.as_ptr() as _,
+                internal_key.len() as _,
+                &mut user_key as *mut *const u8 as _,
+                &mut user_key_length as _,
+                &mut sequence as _,
+                &mut entry_type as _,
+            );
+            if !success {
+                return Err(String::from("invalid full key"));
+            }
+            Ok(FullKey {
+                user_key: slice::from_raw_parts(user_key, user_key_length),
+                sequence,
+                entry_type,
+            })
+        }
+    }
 }
 
 /// # Safety
@@ -972,6 +1005,7 @@ extern "C" {
         v: bool,
     );
     pub fn crocksdb_readoptions_set_ignore_range_deletions(readopts: *mut DBReadOptions, v: bool);
+    pub fn crocksdb_readoptions_set_iter_start_seqnum(readopts: *mut DBReadOptions, v: u64);
     pub fn crocksdb_readoptions_set_table_filter(
         readopts: *mut DBReadOptions,
         ctx: *mut c_void,
@@ -1117,6 +1151,7 @@ extern "C" {
     pub fn crocksdb_iter_prev(iter: *mut DBIterator);
     pub fn crocksdb_iter_key(iter: *const DBIterator, klen: *mut size_t) -> *mut u8;
     pub fn crocksdb_iter_value(iter: *const DBIterator, vlen: *mut size_t) -> *mut u8;
+    pub fn crocksdb_iter_seqno(iter: *const DBIterator, seqno: *mut u64) -> bool;
     pub fn crocksdb_iter_get_error(iter: *const DBIterator, err: *mut *mut c_char);
     // Write batch
     pub fn crocksdb_write(
@@ -2466,6 +2501,15 @@ extern "C" {
         argv: *const *const c_char,
         opts: *const Options,
     );
+
+    fn parse_full_key(
+        key: *const c_char,
+        length: size_t,
+        user_key: *mut *const c_char,
+        user_key_length: *mut size_t,
+        sequence: *mut u64,
+        entry_type: *mut DBEntryType,
+    ) -> bool;
 }
 
 // Titan

--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -8,7 +8,7 @@ pub use crocksdb_ffi::DBCompactionFilter;
 use crocksdb_ffi::{self, DBCompactionFilterContext, DBCompactionFilterFactory};
 use libc::{c_char, c_int, c_void, malloc, memcpy, size_t};
 
-/// Decision used in `CompactionFilter::filter_v2`.
+/// Decision used in `CompactionFilter::filter`.
 pub enum CompactionFilterDecision {
     /// The record will be kept instead of filtered.
     Keep,
@@ -47,6 +47,7 @@ pub trait CompactionFilter {
         &mut self,
         level: usize,
         key: &[u8],
+        _seqno: u64,
         value: &[u8],
         value_type: CompactionFilterValueType,
     ) -> CompactionFilterDecision {
@@ -84,11 +85,12 @@ extern "C" fn destructor(filter: *mut c_void) {
     }
 }
 
-extern "C" fn filter_v2(
+extern "C" fn filter(
     filter: *mut c_void,
     level: c_int,
     key: *const u8,
     key_len: size_t,
+    seqno: u64,
     value_type: CompactionFilterValueType,
     value: *const u8,
     value_len: size_t,
@@ -106,7 +108,7 @@ extern "C" fn filter_v2(
         let filter = &mut (*(filter as *mut CompactionFilterProxy)).filter;
         let key = slice::from_raw_parts(key, key_len);
         let value = slice::from_raw_parts(value, value_len);
-        match filter.filter_v2(level as usize, key, value, value_type) {
+        match filter.filter_v2(level as usize, key, seqno, value, value_type) {
             CompactionFilterDecision::Keep => RawCompactionFilterDecision::Keep,
             CompactionFilterDecision::Remove => RawCompactionFilterDecision::Remove,
             CompactionFilterDecision::ChangeValue(new_v) => {
@@ -155,12 +157,7 @@ pub unsafe fn new_compaction_filter_raw(
         name: c_name,
         filter: f,
     }));
-    crocksdb_ffi::crocksdb_compactionfilter_create_v2(
-        proxy as *mut c_void,
-        destructor,
-        filter_v2,
-        name,
-    )
+    crocksdb_ffi::crocksdb_compactionfilter_create(proxy as *mut c_void, destructor, filter, name)
 }
 
 pub struct CompactionFilterContext(DBCompactionFilterContext);

--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -43,7 +43,7 @@ pub trait CompactionFilter {
     }
 
     /// This method will overwrite `filter` if a `CompactionFilter` implements both of them.
-    fn filter_v2(
+    fn featured_filter(
         &mut self,
         level: usize,
         key: &[u8],
@@ -108,7 +108,7 @@ extern "C" fn filter(
         let filter = &mut (*(filter as *mut CompactionFilterProxy)).filter;
         let key = slice::from_raw_parts(key, key_len);
         let value = slice::from_raw_parts(value, value_len);
-        match filter.filter_v2(level as usize, key, seqno, value, value_type) {
+        match filter.featured_filter(level as usize, key, seqno, value, value_type) {
             CompactionFilterDecision::Keep => RawCompactionFilterDecision::Keep,
             CompactionFilterDecision::Remove => RawCompactionFilterDecision::Remove,
             CompactionFilterDecision::ChangeValue(new_v) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,7 @@ pub use librocksdb_sys::{
     DBBackgroundErrorReason, DBBottommostLevelCompaction, DBCompactionStyle, DBCompressionType,
     DBEntryType, DBInfoLogLevel, DBRateLimiterMode, DBRecoveryMode,
     DBSstPartitionerResult as SstPartitionerResult, DBStatisticsHistogramType,
-    DBStatisticsTickerType, DBStatusPtr, DBTitanDBBlobRunMode, FullKey, IndexType,
-    WriteStallCondition,
+    DBStatisticsTickerType, DBStatusPtr, DBTitanDBBlobRunMode, IndexType, WriteStallCondition,
 };
 pub use logger::Logger;
 pub use merge_operator::MergeOperands;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,8 @@ pub use librocksdb_sys::{
     DBBackgroundErrorReason, DBBottommostLevelCompaction, DBCompactionStyle, DBCompressionType,
     DBEntryType, DBInfoLogLevel, DBRateLimiterMode, DBRecoveryMode,
     DBSstPartitionerResult as SstPartitionerResult, DBStatisticsHistogramType,
-    DBStatisticsTickerType, DBStatusPtr, DBTitanDBBlobRunMode, IndexType, WriteStallCondition,
+    DBStatisticsTickerType, DBStatusPtr, DBTitanDBBlobRunMode, FullKey, IndexType,
+    WriteStallCondition,
 };
 pub use logger::Logger;
 pub use merge_operator::MergeOperands;

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -305,6 +305,17 @@ impl<D> DBIterator<D> {
         }
     }
 
+    pub fn sequence(&self) -> Option<u64> {
+        debug_assert_eq!(self.valid(), Ok(true));
+        unsafe {
+            let mut seqno = 0;
+            if crocksdb_ffi::crocksdb_iter_seqno(self.inner, &mut seqno) {
+                return Some(seqno);
+            }
+            None
+        }
+    }
+
     #[deprecated]
     pub fn kv(&self) -> Option<(Vec<u8>, Vec<u8>)> {
         if self.valid().unwrap() {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -457,6 +457,12 @@ impl ReadOptions {
         }
     }
 
+    pub fn set_iter_start_seqnum(&mut self, seqnum: u64) {
+        unsafe {
+            crocksdb_ffi::crocksdb_readoptions_set_iter_start_seqnum(self.inner, seqnum);
+        }
+    }
+
     pub fn get_inner(&self) -> *const DBReadOptions {
         self.inner
     }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -457,12 +457,6 @@ impl ReadOptions {
         }
     }
 
-    pub fn set_iter_start_seqnum(&mut self, seqnum: u64) {
-        unsafe {
-            crocksdb_ffi::crocksdb_readoptions_set_iter_start_seqnum(self.inner, seqnum);
-        }
-    }
-
     pub fn get_inner(&self) -> *const DBReadOptions {
         self.inner
     }

--- a/tests/cases/test_iterator.rs
+++ b/tests/cases/test_iterator.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 use std::ops::Deref;
+use std::sync::mpsc::{self, SyncSender};
 use std::sync::*;
 use std::thread;
 
@@ -408,4 +409,73 @@ fn test_fixed_suffix_seek() {
     iter.seek(SeekKey::Key(b"k-24yfa-9")).unwrap();
     let vec = prev_collect(&mut iter);
     assert!(vec.len() == 0);
+}
+
+#[test]
+fn test_iter_sequence_number() {
+    struct TestCompactionFilter(SyncSender<(Vec<u8>, Vec<u8>, u64)>);
+    impl CompactionFilter for TestCompactionFilter {
+        fn filter_v2(
+            &mut self,
+            _: usize,
+            key: &[u8],
+            seqno: u64,
+            value: &[u8],
+            _: CompactionFilterValueType,
+        ) -> CompactionFilterDecision {
+            self.0.send((key.to_vec(), value.to_vec(), seqno)).unwrap();
+            CompactionFilterDecision::Keep
+        }
+    }
+    let (tx, rx) = mpsc::sync_channel(8);
+    let filter = Box::new(TestCompactionFilter(tx));
+
+    let path = tempdir_with_prefix("_rust_rocksdb_sequence_number");
+    let mut opts = DBOptions::new();
+    opts.create_if_missing(true);
+    let mut cf_opts = ColumnFamilyOptions::new();
+    cf_opts.set_disable_auto_compactions(true);
+    cf_opts.set_num_levels(7);
+    cf_opts.set_compaction_filter("test", filter).unwrap();
+    let db = DB::open_cf(
+        opts,
+        path.path().to_str().unwrap(),
+        vec![("default", cf_opts)],
+    )
+    .unwrap();
+
+    db.put(b"key1", b"value11").unwrap();
+    db.flush(false).unwrap();
+    db.put(b"key1", b"value22").unwrap();
+    db.flush(false).unwrap();
+    db.put(b"key2", b"value21").unwrap();
+    db.flush(false).unwrap();
+    db.put(b"key2", b"value22").unwrap();
+
+    let mut iter = db.iter();
+    assert!(iter.seek(SeekKey::Key(b"key1")).unwrap());
+    assert_eq!(iter.key(), b"key1");
+    assert_eq!(iter.value(), b"value22");
+    assert_eq!(iter.sequence().unwrap(), 2);
+
+    assert!(iter.next().unwrap());
+    assert_eq!(iter.key(), b"key2");
+    assert_eq!(iter.value(), b"value22");
+    assert_eq!(iter.sequence().unwrap(), 4);
+
+    let mut compact_opts = CompactOptions::new();
+    compact_opts.set_bottommost_level_compaction(DBBottommostLevelCompaction::Force);
+    compact_opts.set_target_level(6);
+    let cf_default = db.cf_handle("default").unwrap();
+    db.compact_range_cf_opt(cf_default, &compact_opts, Some(b"a"), Some(b"z"));
+
+    let (k, v, seqno) = rx.recv().unwrap();
+    assert_eq!(k, b"key1");
+    assert_eq!(v, b"value22");
+    assert_eq!(seqno, 2);
+
+    let (k, v, seqno) = rx.recv().unwrap();
+    assert_eq!(k, b"key2");
+    assert_eq!(v, b"value22");
+    assert_eq!(seqno, 4);
 }

--- a/tests/cases/test_iterator.rs
+++ b/tests/cases/test_iterator.rs
@@ -415,7 +415,7 @@ fn test_fixed_suffix_seek() {
 fn test_iter_sequence_number() {
     struct TestCompactionFilter(SyncSender<(Vec<u8>, Vec<u8>, u64)>);
     impl CompactionFilter for TestCompactionFilter {
-        fn filter_v2(
+        fn featured_filter(
             &mut self,
             _: usize,
             key: &[u8],


### PR DESCRIPTION
This PR supports to access seqno for every key/value pairs in compaction filter or iterator.
It's helpful to enhance GC in compaction filter in TiKV.