### PR TITLE
Port file system inspector

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
-	url = https://github.com/tabokie/rocksdb.git
-	branch = inspect-fs
+	url = https://github.com/tikv/rocksdb.git
+	branch = 6.4.tikv
 
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
-	url = https://github.com/tikv/rocksdb.git
-	branch = 6.4.tikv
+	url = https://github.com/tabokie/rocksdb.git
+	branch = inspect-fs
 
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan

--- a/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -3273,7 +3273,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    pub fn crocksdb_file_system_inspected_create(
+    pub fn crocksdb_file_system_inspected_env_create(
         arg1: *mut crocksdb_env_t,
         arg2: *mut crocksdb_file_system_inspector_t,
     ) -> *mut crocksdb_env_t;

--- a/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -3233,12 +3233,10 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_sequential_file_destroy(arg1: *mut crocksdb_sequential_file_t);
 }
-pub type crocksdb_file_system_inspector_read_cb = ::std::option::Option<
-    unsafe extern "C" fn(state: *mut libc::c_void, io_type: libc::c_int, len: usize) -> usize,
->;
-pub type crocksdb_file_system_inspector_write_cb = ::std::option::Option<
-    unsafe extern "C" fn(state: *mut libc::c_void, io_type: libc::c_int, len: usize) -> usize,
->;
+pub type crocksdb_file_system_inspector_read_cb =
+    ::std::option::Option<unsafe extern "C" fn(state: *mut libc::c_void, len: usize) -> usize>;
+pub type crocksdb_file_system_inspector_write_cb =
+    ::std::option::Option<unsafe extern "C" fn(state: *mut libc::c_void, len: usize) -> usize>;
 extern "C" {
     pub fn crocksdb_file_system_inspector_create(
         state: *mut libc::c_void,
@@ -3253,14 +3251,12 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_file_system_inspector_read(
         inspector: *mut crocksdb_file_system_inspector_t,
-        io_type: libc::c_int,
         len: usize,
     ) -> usize;
 }
 extern "C" {
     pub fn crocksdb_file_system_inspector_write(
         inspector: *mut crocksdb_file_system_inspector_t,
-        io_type: libc::c_int,
         len: usize,
     ) -> usize;
 }

--- a/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -3233,10 +3233,20 @@ extern "C" {
 extern "C" {
     pub fn crocksdb_sequential_file_destroy(arg1: *mut crocksdb_sequential_file_t);
 }
-pub type crocksdb_file_system_inspector_read_cb =
-    ::std::option::Option<unsafe extern "C" fn(state: *mut libc::c_void, len: usize) -> usize>;
-pub type crocksdb_file_system_inspector_write_cb =
-    ::std::option::Option<unsafe extern "C" fn(state: *mut libc::c_void, len: usize) -> usize>;
+pub type crocksdb_file_system_inspector_read_cb = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut libc::c_void,
+        len: usize,
+        errptr: *mut *mut libc::c_char,
+    ) -> usize,
+>;
+pub type crocksdb_file_system_inspector_write_cb = ::std::option::Option<
+    unsafe extern "C" fn(
+        state: *mut libc::c_void,
+        len: usize,
+        errptr: *mut *mut libc::c_char,
+    ) -> usize,
+>;
 extern "C" {
     pub fn crocksdb_file_system_inspector_create(
         state: *mut libc::c_void,
@@ -3252,12 +3262,14 @@ extern "C" {
     pub fn crocksdb_file_system_inspector_read(
         inspector: *mut crocksdb_file_system_inspector_t,
         len: usize,
+        errptr: *mut *mut libc::c_char,
     ) -> usize;
 }
 extern "C" {
     pub fn crocksdb_file_system_inspector_write(
         inspector: *mut crocksdb_file_system_inspector_t,
         len: usize,
+        errptr: *mut *mut libc::c_char,
     ) -> usize;
 }
 extern "C" {

--- a/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -3,14 +3,14 @@
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _STDINT_H: u32 = 1;
 pub const _FEATURES_H: u32 = 1;
-pub const _DEFAULT_SOURCE: u32 = 1;
-pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const _BSD_SOURCE: u32 = 1;
+pub const _SVID_SOURCE: u32 = 1;
 pub const __USE_ISOC11: u32 = 1;
 pub const __USE_ISOC99: u32 = 1;
 pub const __USE_ISOC95: u32 = 1;
-pub const __USE_POSIX_IMPLICITLY: u32 = 1;
 pub const _POSIX_SOURCE: u32 = 1;
 pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
 pub const __USE_POSIX: u32 = 1;
 pub const __USE_POSIX2: u32 = 1;
 pub const __USE_POSIX199309: u32 = 1;
@@ -19,42 +19,23 @@ pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
 pub const __USE_MISC: u32 = 1;
+pub const __USE_BSD: u32 = 1;
+pub const __USE_SVID: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
-pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __STDC_ISO_10646__: u32 = 201103;
+pub const __STDC_NO_THREADS__: u32 = 1;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 31;
+pub const __GLIBC_MINOR__: u32 = 18;
 pub const _SYS_CDEFS_H: u32 = 1;
-pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __WORDSIZE: u32 = 64;
 pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
 pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
-pub const __HAVE_GENERIC_SELECTION: u32 = 1;
-pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
-pub const _BITS_TYPES_H: u32 = 1;
-pub const __TIMESIZE: u32 = 64;
-pub const _BITS_TYPESIZES_H: u32 = 1;
-pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
-pub const __INO_T_MATCHES_INO64_T: u32 = 1;
-pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
-pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __FD_SETSIZE: u32 = 1024;
-pub const _BITS_TIME64_H: u32 = 1;
 pub const _BITS_WCHAR_H: u32 = 1;
-pub const _BITS_STDINT_INTN_H: u32 = 1;
-pub const _BITS_STDINT_UINTN_H: u32 = 1;
 pub const INT8_MIN: i32 = -128;
 pub const INT16_MIN: i32 = -32768;
 pub const INT32_MIN: i32 = -2147483648;
@@ -140,103 +121,14 @@ fn bindgen_test_layout_max_align_t() {
         )
     );
 }
-pub type __u_char = libc::c_uchar;
-pub type __u_short = libc::c_ushort;
-pub type __u_int = libc::c_uint;
-pub type __u_long = libc::c_ulong;
-pub type __int8_t = libc::c_schar;
-pub type __uint8_t = libc::c_uchar;
-pub type __int16_t = libc::c_short;
-pub type __uint16_t = libc::c_ushort;
-pub type __int32_t = libc::c_int;
-pub type __uint32_t = libc::c_uint;
-pub type __int64_t = libc::c_long;
-pub type __uint64_t = libc::c_ulong;
-pub type __int_least8_t = __int8_t;
-pub type __uint_least8_t = __uint8_t;
-pub type __int_least16_t = __int16_t;
-pub type __uint_least16_t = __uint16_t;
-pub type __int_least32_t = __int32_t;
-pub type __uint_least32_t = __uint32_t;
-pub type __int_least64_t = __int64_t;
-pub type __uint_least64_t = __uint64_t;
-pub type __quad_t = libc::c_long;
-pub type __u_quad_t = libc::c_ulong;
-pub type __intmax_t = libc::c_long;
-pub type __uintmax_t = libc::c_ulong;
-pub type __dev_t = libc::c_ulong;
-pub type __uid_t = libc::c_uint;
-pub type __gid_t = libc::c_uint;
-pub type __ino_t = libc::c_ulong;
-pub type __ino64_t = libc::c_ulong;
-pub type __mode_t = libc::c_uint;
-pub type __nlink_t = libc::c_ulong;
-pub type __off_t = libc::c_long;
-pub type __off64_t = libc::c_long;
-pub type __pid_t = libc::c_int;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __fsid_t {
-    pub __val: [libc::c_int; 2usize],
-}
-#[test]
-fn bindgen_test_layout___fsid_t() {
-    assert_eq!(
-        ::std::mem::size_of::<__fsid_t>(),
-        8usize,
-        concat!("Size of: ", stringify!(__fsid_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<__fsid_t>(),
-        4usize,
-        concat!("Alignment of ", stringify!(__fsid_t))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<__fsid_t>())).__val as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__fsid_t),
-            "::",
-            stringify!(__val)
-        )
-    );
-}
-pub type __clock_t = libc::c_long;
-pub type __rlim_t = libc::c_ulong;
-pub type __rlim64_t = libc::c_ulong;
-pub type __id_t = libc::c_uint;
-pub type __time_t = libc::c_long;
-pub type __useconds_t = libc::c_uint;
-pub type __suseconds_t = libc::c_long;
-pub type __daddr_t = libc::c_int;
-pub type __key_t = libc::c_int;
-pub type __clockid_t = libc::c_int;
-pub type __timer_t = *mut libc::c_void;
-pub type __blksize_t = libc::c_long;
-pub type __blkcnt_t = libc::c_long;
-pub type __blkcnt64_t = libc::c_long;
-pub type __fsblkcnt_t = libc::c_ulong;
-pub type __fsblkcnt64_t = libc::c_ulong;
-pub type __fsfilcnt_t = libc::c_ulong;
-pub type __fsfilcnt64_t = libc::c_ulong;
-pub type __fsword_t = libc::c_long;
-pub type __ssize_t = libc::c_long;
-pub type __syscall_slong_t = libc::c_long;
-pub type __syscall_ulong_t = libc::c_ulong;
-pub type __loff_t = __off64_t;
-pub type __caddr_t = *mut libc::c_char;
-pub type __intptr_t = libc::c_long;
-pub type __socklen_t = libc::c_uint;
-pub type __sig_atomic_t = libc::c_int;
-pub type int_least8_t = __int_least8_t;
-pub type int_least16_t = __int_least16_t;
-pub type int_least32_t = __int_least32_t;
-pub type int_least64_t = __int_least64_t;
-pub type uint_least8_t = __uint_least8_t;
-pub type uint_least16_t = __uint_least16_t;
-pub type uint_least32_t = __uint_least32_t;
-pub type uint_least64_t = __uint_least64_t;
+pub type int_least8_t = libc::c_schar;
+pub type int_least16_t = libc::c_short;
+pub type int_least32_t = libc::c_int;
+pub type int_least64_t = libc::c_long;
+pub type uint_least8_t = libc::c_uchar;
+pub type uint_least16_t = libc::c_ushort;
+pub type uint_least32_t = libc::c_uint;
+pub type uint_least64_t = libc::c_ulong;
 pub type int_fast8_t = libc::c_schar;
 pub type int_fast16_t = libc::c_long;
 pub type int_fast32_t = libc::c_long;
@@ -245,8 +137,8 @@ pub type uint_fast8_t = libc::c_uchar;
 pub type uint_fast16_t = libc::c_ulong;
 pub type uint_fast32_t = libc::c_ulong;
 pub type uint_fast64_t = libc::c_ulong;
-pub type intmax_t = __intmax_t;
-pub type uintmax_t = __uintmax_t;
+pub type intmax_t = libc::c_long;
+pub type uintmax_t = libc::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct crocksdb_cloud_envoptions_t {
@@ -637,6 +529,11 @@ pub const crocksdb_backgrounderrorreason_t_kCompaction: crocksdb_backgrounderror
 pub const crocksdb_backgrounderrorreason_t_kWriteCallback: crocksdb_backgrounderrorreason_t = 3;
 pub const crocksdb_backgrounderrorreason_t_kMemTable: crocksdb_backgrounderrorreason_t = 4;
 pub type crocksdb_backgrounderrorreason_t = u32;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct crocksdb_file_system_inspector_t {
+    _unused: [u8; 0],
+}
 extern "C" {
     pub fn crocksdb_open(
         options: *const crocksdb_options_t,
@@ -2875,6 +2772,19 @@ extern "C" {
     ) -> libc::c_uchar;
 }
 extern "C" {
+    pub fn crocksdb_compactionfiltercontext_file_numbers(
+        context: *mut crocksdb_compactionfiltercontext_t,
+        buffer: *mut *const u64,
+        len: *mut usize,
+    );
+}
+extern "C" {
+    pub fn crocksdb_compactionfiltercontext_table_properties(
+        context: *mut crocksdb_compactionfiltercontext_t,
+        offset: usize,
+    ) -> *mut crocksdb_table_properties_t;
+}
+extern "C" {
     pub fn crocksdb_compactionfilterfactory_create(
         state: *mut libc::c_void,
         destructor: ::std::option::Option<unsafe extern "C" fn(arg1: *mut libc::c_void)>,
@@ -3322,6 +3232,43 @@ extern "C" {
 }
 extern "C" {
     pub fn crocksdb_sequential_file_destroy(arg1: *mut crocksdb_sequential_file_t);
+}
+pub type crocksdb_file_system_inspector_read_cb = ::std::option::Option<
+    unsafe extern "C" fn(state: *mut libc::c_void, io_type: libc::c_int, len: usize) -> usize,
+>;
+pub type crocksdb_file_system_inspector_write_cb = ::std::option::Option<
+    unsafe extern "C" fn(state: *mut libc::c_void, io_type: libc::c_int, len: usize) -> usize,
+>;
+extern "C" {
+    pub fn crocksdb_file_system_inspector_create(
+        state: *mut libc::c_void,
+        destructor: ::std::option::Option<unsafe extern "C" fn(arg1: *mut libc::c_void)>,
+        read: crocksdb_file_system_inspector_read_cb,
+        write: crocksdb_file_system_inspector_write_cb,
+    ) -> *mut crocksdb_file_system_inspector_t;
+}
+extern "C" {
+    pub fn crocksdb_file_system_inspector_destroy(arg1: *mut crocksdb_file_system_inspector_t);
+}
+extern "C" {
+    pub fn crocksdb_file_system_inspector_read(
+        inspector: *mut crocksdb_file_system_inspector_t,
+        io_type: libc::c_int,
+        len: usize,
+    ) -> usize;
+}
+extern "C" {
+    pub fn crocksdb_file_system_inspector_write(
+        inspector: *mut crocksdb_file_system_inspector_t,
+        io_type: libc::c_int,
+        len: usize,
+    ) -> usize;
+}
+extern "C" {
+    pub fn crocksdb_file_system_inspected_create(
+        arg1: *mut crocksdb_env_t,
+        arg2: *mut crocksdb_file_system_inspector_t,
+    ) -> *mut crocksdb_env_t;
 }
 extern "C" {
     pub fn crocksdb_sstfilereader_create(

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -954,9 +954,10 @@ crocksdb_column_family_handle_t* crocksdb_create_column_family(
     crocksdb_t* db, const crocksdb_options_t* column_family_options,
     const char* column_family_name, char** errptr) {
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr, db->rep->CreateColumnFamily(
-                        ColumnFamilyOptions(column_family_options->rep),
-                        std::string(column_family_name), &(handle->rep)));
+  SaveError(errptr,
+            db->rep->CreateColumnFamily(
+                ColumnFamilyOptions(column_family_options->rep),
+                std::string(column_family_name), &(handle->rep)));
   return handle;
 }
 
@@ -988,8 +989,9 @@ void crocksdb_put_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                      crocksdb_column_family_handle_t* column_family,
                      const char* key, size_t keylen, const char* val,
                      size_t vallen, char** errptr) {
-  SaveError(errptr, db->rep->Put(options->rep, column_family->rep,
-                                 Slice(key, keylen), Slice(val, vallen)));
+  SaveError(errptr,
+            db->rep->Put(options->rep, column_family->rep, Slice(key, keylen),
+                         Slice(val, vallen)));
 }
 
 void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -1000,8 +1002,9 @@ void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
 void crocksdb_delete_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                         crocksdb_column_family_handle_t* column_family,
                         const char* key, size_t keylen, char** errptr) {
-  SaveError(errptr, db->rep->Delete(options->rep, column_family->rep,
-                                    Slice(key, keylen)));
+  SaveError(
+      errptr,
+      db->rep->Delete(options->rep, column_family->rep, Slice(key, keylen)));
 }
 
 void crocksdb_single_delete(crocksdb_t* db,
@@ -1014,8 +1017,9 @@ void crocksdb_single_delete_cf(crocksdb_t* db,
                                const crocksdb_writeoptions_t* options,
                                crocksdb_column_family_handle_t* column_family,
                                const char* key, size_t keylen, char** errptr) {
-  SaveError(errptr, db->rep->SingleDelete(options->rep, column_family->rep,
-                                          Slice(key, keylen)));
+  SaveError(errptr,
+            db->rep->SingleDelete(options->rep, column_family->rep,
+                                  Slice(key, keylen)));
 }
 
 void crocksdb_delete_range_cf(crocksdb_t* db,
@@ -1024,24 +1028,27 @@ void crocksdb_delete_range_cf(crocksdb_t* db,
                               const char* begin_key, size_t begin_keylen,
                               const char* end_key, size_t end_keylen,
                               char** errptr) {
-  SaveError(errptr, db->rep->DeleteRange(options->rep, column_family->rep,
-                                         Slice(begin_key, begin_keylen),
-                                         Slice(end_key, end_keylen)));
+  SaveError(errptr,
+            db->rep->DeleteRange(options->rep, column_family->rep,
+                                 Slice(begin_key, begin_keylen),
+                                 Slice(end_key, end_keylen)));
 }
 
 void crocksdb_merge(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                     const char* key, size_t keylen, const char* val,
                     size_t vallen, char** errptr) {
-  SaveError(errptr, db->rep->Merge(options->rep, Slice(key, keylen),
-                                   Slice(val, vallen)));
+  SaveError(
+      errptr,
+      db->rep->Merge(options->rep, Slice(key, keylen), Slice(val, vallen)));
 }
 
 void crocksdb_merge_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                        crocksdb_column_family_handle_t* column_family,
                        const char* key, size_t keylen, const char* val,
                        size_t vallen, char** errptr) {
-  SaveError(errptr, db->rep->Merge(options->rep, column_family->rep,
-                                   Slice(key, keylen), Slice(val, vallen)));
+  SaveError(errptr,
+            db->rep->Merge(options->rep, column_family->rep, Slice(key, keylen),
+                           Slice(val, vallen)));
 }
 
 void crocksdb_write(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -4119,13 +4126,9 @@ struct crocksdb_file_system_inspector_impl_t : public FileSystemInspector {
 
   virtual ~crocksdb_file_system_inspector_impl_t() { destructor(state); }
 
-  size_t Read(Env::IOType io_type, size_t len) {
-    return read(state, static_cast<int>(io_type), len);
-  }
+  size_t Read(Esize_t len) { return read(state, len); }
 
-  size_t Write(Env::IOType io_type, size_t len) {
-    return write(state, static_cast<int>(io_type), len);
-  }
+  size_t Write(Esize_t len) { return write(state, len); }
 };
 
 crocksdb_file_system_inspector_t* crocksdb_file_system_inspector_create(
@@ -4150,15 +4153,15 @@ void crocksdb_file_system_inspector_destroy(
 }
 
 size_t crocksdb_file_system_inspector_read(
-    crocksdb_file_system_inspector_t* inspector, int io_type, size_t len) {
+    crocksdb_file_system_inspector_t* inspector, size_t len) {
   assert(inspector != nullptr && inspector->rep != nullptr);
-  return inspector->rep->Read(static_cast<Env::IOType>(io_type), len);
+  return inspector->rep->Read(len);
 }
 
 size_t crocksdb_file_system_inspector_write(
-    crocksdb_file_system_inspector_t* inspector, int io_type, size_t len) {
+    crocksdb_file_system_inspector_t* inspector, size_t len) {
   assert(inspector != nullptr && inspector->rep != nullptr);
-  return inspector->rep->Write(static_cast<Env::IOType>(io_type), len);
+  return inspector->rep->Write(len);
 }
 
 crocksdb_env_t* crocksdb_file_system_inspected_create(
@@ -4251,8 +4254,9 @@ void crocksdb_sstfilewriter_delete_range(crocksdb_sstfilewriter_t* writer,
                                          size_t begin_keylen,
                                          const char* end_key, size_t end_keylen,
                                          char** errptr) {
-  SaveError(errptr, writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
-                                             Slice(end_key, end_keylen)));
+  SaveError(errptr,
+            writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
+                                     Slice(end_key, end_keylen)));
 }
 
 void crocksdb_sstfilewriter_finish(crocksdb_sstfilewriter_t* writer,
@@ -6108,10 +6112,11 @@ crocksdb_column_family_handle_t* ctitandb_create_column_family(
   // Blindly cast db into TitanDB.
   TitanDB* titan_db = reinterpret_cast<TitanDB*>(db->rep);
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr, titan_db->CreateColumnFamily(
-                        TitanCFDescriptor(std::string(column_family_name),
-                                          titan_column_family_options->rep),
-                        &(handle->rep)));
+  SaveError(errptr,
+            titan_db->CreateColumnFamily(
+                TitanCFDescriptor(std::string(column_family_name),
+                                  titan_column_family_options->rep),
+                &(handle->rep)));
   return handle;
 }
 
@@ -6410,8 +6415,9 @@ void ctitandb_delete_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                        column_family->rep, &range, 1, include_end));
+  SaveError(errptr,
+            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_files_in_ranges_cf(
@@ -6435,8 +6441,9 @@ void ctitandb_delete_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                        cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr,
+            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 void ctitandb_delete_blob_files_in_range(crocksdb_t* db, const char* start_key,
@@ -6464,8 +6471,9 @@ void ctitandb_delete_blob_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                        column_family->rep, &range, 1, include_end));
+  SaveError(errptr,
+            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_blob_files_in_ranges_cf(
@@ -6489,8 +6497,9 @@ void ctitandb_delete_blob_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                        cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr,
+            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 /* RocksDB Cloud */

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4126,9 +4126,9 @@ struct crocksdb_file_system_inspector_impl_t : public FileSystemInspector {
 
   virtual ~crocksdb_file_system_inspector_impl_t() { destructor(state); }
 
-  size_t Read(Esize_t len) { return read(state, len); }
+  size_t Read(size_t len) { return read(state, len); }
 
-  size_t Write(Esize_t len) { return write(state, len); }
+  size_t Write(size_t len) { return write(state, len); }
 };
 
 crocksdb_file_system_inspector_t* crocksdb_file_system_inspector_create(

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -954,10 +954,9 @@ crocksdb_column_family_handle_t* crocksdb_create_column_family(
     crocksdb_t* db, const crocksdb_options_t* column_family_options,
     const char* column_family_name, char** errptr) {
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr,
-            db->rep->CreateColumnFamily(
-                ColumnFamilyOptions(column_family_options->rep),
-                std::string(column_family_name), &(handle->rep)));
+  SaveError(errptr, db->rep->CreateColumnFamily(
+                        ColumnFamilyOptions(column_family_options->rep),
+                        std::string(column_family_name), &(handle->rep)));
   return handle;
 }
 
@@ -989,9 +988,8 @@ void crocksdb_put_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                      crocksdb_column_family_handle_t* column_family,
                      const char* key, size_t keylen, const char* val,
                      size_t vallen, char** errptr) {
-  SaveError(errptr,
-            db->rep->Put(options->rep, column_family->rep, Slice(key, keylen),
-                         Slice(val, vallen)));
+  SaveError(errptr, db->rep->Put(options->rep, column_family->rep,
+                                 Slice(key, keylen), Slice(val, vallen)));
 }
 
 void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -1002,9 +1000,8 @@ void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
 void crocksdb_delete_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                         crocksdb_column_family_handle_t* column_family,
                         const char* key, size_t keylen, char** errptr) {
-  SaveError(
-      errptr,
-      db->rep->Delete(options->rep, column_family->rep, Slice(key, keylen)));
+  SaveError(errptr, db->rep->Delete(options->rep, column_family->rep,
+                                    Slice(key, keylen)));
 }
 
 void crocksdb_single_delete(crocksdb_t* db,
@@ -1017,9 +1014,8 @@ void crocksdb_single_delete_cf(crocksdb_t* db,
                                const crocksdb_writeoptions_t* options,
                                crocksdb_column_family_handle_t* column_family,
                                const char* key, size_t keylen, char** errptr) {
-  SaveError(errptr,
-            db->rep->SingleDelete(options->rep, column_family->rep,
-                                  Slice(key, keylen)));
+  SaveError(errptr, db->rep->SingleDelete(options->rep, column_family->rep,
+                                          Slice(key, keylen)));
 }
 
 void crocksdb_delete_range_cf(crocksdb_t* db,
@@ -1028,27 +1024,24 @@ void crocksdb_delete_range_cf(crocksdb_t* db,
                               const char* begin_key, size_t begin_keylen,
                               const char* end_key, size_t end_keylen,
                               char** errptr) {
-  SaveError(errptr,
-            db->rep->DeleteRange(options->rep, column_family->rep,
-                                 Slice(begin_key, begin_keylen),
-                                 Slice(end_key, end_keylen)));
+  SaveError(errptr, db->rep->DeleteRange(options->rep, column_family->rep,
+                                         Slice(begin_key, begin_keylen),
+                                         Slice(end_key, end_keylen)));
 }
 
 void crocksdb_merge(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                     const char* key, size_t keylen, const char* val,
                     size_t vallen, char** errptr) {
-  SaveError(
-      errptr,
-      db->rep->Merge(options->rep, Slice(key, keylen), Slice(val, vallen)));
+  SaveError(errptr, db->rep->Merge(options->rep, Slice(key, keylen),
+                                   Slice(val, vallen)));
 }
 
 void crocksdb_merge_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                        crocksdb_column_family_handle_t* column_family,
                        const char* key, size_t keylen, const char* val,
                        size_t vallen, char** errptr) {
-  SaveError(errptr,
-            db->rep->Merge(options->rep, column_family->rep, Slice(key, keylen),
-                           Slice(val, vallen)));
+  SaveError(errptr, db->rep->Merge(options->rep, column_family->rep,
+                                   Slice(key, keylen), Slice(val, vallen)));
 }
 
 void crocksdb_write(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -4258,9 +4251,8 @@ void crocksdb_sstfilewriter_delete_range(crocksdb_sstfilewriter_t* writer,
                                          size_t begin_keylen,
                                          const char* end_key, size_t end_keylen,
                                          char** errptr) {
-  SaveError(errptr,
-            writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
-                                     Slice(end_key, end_keylen)));
+  SaveError(errptr, writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
+                                             Slice(end_key, end_keylen)));
 }
 
 void crocksdb_sstfilewriter_finish(crocksdb_sstfilewriter_t* writer,
@@ -6116,11 +6108,10 @@ crocksdb_column_family_handle_t* ctitandb_create_column_family(
   // Blindly cast db into TitanDB.
   TitanDB* titan_db = reinterpret_cast<TitanDB*>(db->rep);
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr,
-            titan_db->CreateColumnFamily(
-                TitanCFDescriptor(std::string(column_family_name),
-                                  titan_column_family_options->rep),
-                &(handle->rep)));
+  SaveError(errptr, titan_db->CreateColumnFamily(
+                        TitanCFDescriptor(std::string(column_family_name),
+                                          titan_column_family_options->rep),
+                        &(handle->rep)));
   return handle;
 }
 
@@ -6419,9 +6410,8 @@ void ctitandb_delete_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                column_family->rep, &range, 1, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                        column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_files_in_ranges_cf(
@@ -6445,9 +6435,8 @@ void ctitandb_delete_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                        cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 void ctitandb_delete_blob_files_in_range(crocksdb_t* db, const char* start_key,
@@ -6475,9 +6464,8 @@ void ctitandb_delete_blob_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                column_family->rep, &range, 1, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                        column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_blob_files_in_ranges_cf(
@@ -6501,9 +6489,8 @@ void ctitandb_delete_blob_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                        cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 /* RocksDB Cloud */

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4162,7 +4162,7 @@ size_t crocksdb_file_system_inspector_read(
     crocksdb_file_system_inspector_t* inspector, size_t len, char** errptr) {
   assert(inspector != nullptr && inspector->rep != nullptr);
   size_t allowed = 0;
-  SaveError(errptr, inspector->rep->Read(len, allowed));
+  SaveError(errptr, inspector->rep->Read(len, &allowed));
   return allowed;
 }
 
@@ -4170,7 +4170,7 @@ size_t crocksdb_file_system_inspector_write(
     crocksdb_file_system_inspector_t* inspector, size_t len, char** errptr) {
   assert(inspector != nullptr && inspector->rep != nullptr);
   size_t allowed = 0;
-  SaveError(errptr, inspector->rep->Write(len, allowed));
+  SaveError(errptr, inspector->rep->Write(len, &allowed));
   return allowed;
 }
 

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4124,7 +4124,10 @@ struct crocksdb_file_system_inspector_impl_t : public FileSystemInspector {
     char* err = nullptr;
     *allowed = read(state, len, &err);
     if (err) {
-      return Status::IOError(err);
+      Status s = Status::IOError(err);
+      // malloc-ed by strdup
+      free(err);
+      return s;
     } else {
       return Status::OK();
     }
@@ -4135,7 +4138,10 @@ struct crocksdb_file_system_inspector_impl_t : public FileSystemInspector {
     char* err = nullptr;
     *allowed = write(state, len, &err);
     if (err) {
-      return Status::IOError(err);
+      Status s = Status::IOError(err);
+      // malloc-ed by strdup
+      free(err);
+      return s;
     } else {
       return Status::OK();
     }
@@ -4179,7 +4185,7 @@ size_t crocksdb_file_system_inspector_write(
   return allowed;
 }
 
-crocksdb_env_t* crocksdb_file_system_inspected_create(
+crocksdb_env_t* crocksdb_file_system_inspected_env_create(
     crocksdb_env_t* base_env, crocksdb_file_system_inspector_t* inspector) {
   assert(base_env != nullptr);
   assert(inspector != nullptr);

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4119,9 +4119,10 @@ struct crocksdb_file_system_inspector_impl_t : public FileSystemInspector {
 
   virtual ~crocksdb_file_system_inspector_impl_t() { destructor(state); }
 
-  Status Read(size_t len, size_t& allowed) {
+  Status Read(size_t len, size_t* allowed) {
+    assert(allowed);
     char* err = nullptr;
-    allowed = read(state, len, &err);
+    *allowed = read(state, len, &err);
     if (err) {
       return Status::IOError(err);
     } else {
@@ -4129,9 +4130,10 @@ struct crocksdb_file_system_inspector_impl_t : public FileSystemInspector {
     }
   }
 
-  Status Write(size_t len, size_t& allowed) {
+  Status Write(size_t len, size_t* allowed) {
+    assert(allowed);
     char* err = nullptr;
-    allowed = write(state, len, &err);
+    *allowed = write(state, len, &err);
     if (err) {
       return Status::IOError(err);
     } else {

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -954,10 +954,9 @@ crocksdb_column_family_handle_t* crocksdb_create_column_family(
     crocksdb_t* db, const crocksdb_options_t* column_family_options,
     const char* column_family_name, char** errptr) {
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr,
-            db->rep->CreateColumnFamily(
-                ColumnFamilyOptions(column_family_options->rep),
-                std::string(column_family_name), &(handle->rep)));
+  SaveError(errptr, db->rep->CreateColumnFamily(
+                        ColumnFamilyOptions(column_family_options->rep),
+                        std::string(column_family_name), &(handle->rep)));
   return handle;
 }
 
@@ -989,9 +988,8 @@ void crocksdb_put_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                      crocksdb_column_family_handle_t* column_family,
                      const char* key, size_t keylen, const char* val,
                      size_t vallen, char** errptr) {
-  SaveError(errptr,
-            db->rep->Put(options->rep, column_family->rep, Slice(key, keylen),
-                         Slice(val, vallen)));
+  SaveError(errptr, db->rep->Put(options->rep, column_family->rep,
+                                 Slice(key, keylen), Slice(val, vallen)));
 }
 
 void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -1002,9 +1000,8 @@ void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
 void crocksdb_delete_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                         crocksdb_column_family_handle_t* column_family,
                         const char* key, size_t keylen, char** errptr) {
-  SaveError(
-      errptr,
-      db->rep->Delete(options->rep, column_family->rep, Slice(key, keylen)));
+  SaveError(errptr, db->rep->Delete(options->rep, column_family->rep,
+                                    Slice(key, keylen)));
 }
 
 void crocksdb_single_delete(crocksdb_t* db,
@@ -1017,9 +1014,8 @@ void crocksdb_single_delete_cf(crocksdb_t* db,
                                const crocksdb_writeoptions_t* options,
                                crocksdb_column_family_handle_t* column_family,
                                const char* key, size_t keylen, char** errptr) {
-  SaveError(errptr,
-            db->rep->SingleDelete(options->rep, column_family->rep,
-                                  Slice(key, keylen)));
+  SaveError(errptr, db->rep->SingleDelete(options->rep, column_family->rep,
+                                          Slice(key, keylen)));
 }
 
 void crocksdb_delete_range_cf(crocksdb_t* db,
@@ -1028,27 +1024,24 @@ void crocksdb_delete_range_cf(crocksdb_t* db,
                               const char* begin_key, size_t begin_keylen,
                               const char* end_key, size_t end_keylen,
                               char** errptr) {
-  SaveError(errptr,
-            db->rep->DeleteRange(options->rep, column_family->rep,
-                                 Slice(begin_key, begin_keylen),
-                                 Slice(end_key, end_keylen)));
+  SaveError(errptr, db->rep->DeleteRange(options->rep, column_family->rep,
+                                         Slice(begin_key, begin_keylen),
+                                         Slice(end_key, end_keylen)));
 }
 
 void crocksdb_merge(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                     const char* key, size_t keylen, const char* val,
                     size_t vallen, char** errptr) {
-  SaveError(
-      errptr,
-      db->rep->Merge(options->rep, Slice(key, keylen), Slice(val, vallen)));
+  SaveError(errptr, db->rep->Merge(options->rep, Slice(key, keylen),
+                                   Slice(val, vallen)));
 }
 
 void crocksdb_merge_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                        crocksdb_column_family_handle_t* column_family,
                        const char* key, size_t keylen, const char* val,
                        size_t vallen, char** errptr) {
-  SaveError(errptr,
-            db->rep->Merge(options->rep, column_family->rep, Slice(key, keylen),
-                           Slice(val, vallen)));
+  SaveError(errptr, db->rep->Merge(options->rep, column_family->rep,
+                                   Slice(key, keylen), Slice(val, vallen)));
 }
 
 void crocksdb_write(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -4254,9 +4247,8 @@ void crocksdb_sstfilewriter_delete_range(crocksdb_sstfilewriter_t* writer,
                                          size_t begin_keylen,
                                          const char* end_key, size_t end_keylen,
                                          char** errptr) {
-  SaveError(errptr,
-            writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
-                                     Slice(end_key, end_keylen)));
+  SaveError(errptr, writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
+                                             Slice(end_key, end_keylen)));
 }
 
 void crocksdb_sstfilewriter_finish(crocksdb_sstfilewriter_t* writer,
@@ -6112,11 +6104,10 @@ crocksdb_column_family_handle_t* ctitandb_create_column_family(
   // Blindly cast db into TitanDB.
   TitanDB* titan_db = reinterpret_cast<TitanDB*>(db->rep);
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr,
-            titan_db->CreateColumnFamily(
-                TitanCFDescriptor(std::string(column_family_name),
-                                  titan_column_family_options->rep),
-                &(handle->rep)));
+  SaveError(errptr, titan_db->CreateColumnFamily(
+                        TitanCFDescriptor(std::string(column_family_name),
+                                          titan_column_family_options->rep),
+                        &(handle->rep)));
   return handle;
 }
 
@@ -6415,9 +6406,8 @@ void ctitandb_delete_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                column_family->rep, &range, 1, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                        column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_files_in_ranges_cf(
@@ -6441,9 +6431,8 @@ void ctitandb_delete_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                        cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 void ctitandb_delete_blob_files_in_range(crocksdb_t* db, const char* start_key,
@@ -6471,9 +6460,8 @@ void ctitandb_delete_blob_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                column_family->rep, &range, 1, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                        column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_blob_files_in_ranges_cf(
@@ -6497,9 +6485,8 @@ void ctitandb_delete_blob_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                        cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 /* RocksDB Cloud */

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -954,10 +954,9 @@ crocksdb_column_family_handle_t* crocksdb_create_column_family(
     crocksdb_t* db, const crocksdb_options_t* column_family_options,
     const char* column_family_name, char** errptr) {
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr,
-            db->rep->CreateColumnFamily(
-                ColumnFamilyOptions(column_family_options->rep),
-                std::string(column_family_name), &(handle->rep)));
+  SaveError(errptr, db->rep->CreateColumnFamily(
+                        ColumnFamilyOptions(column_family_options->rep),
+                        std::string(column_family_name), &(handle->rep)));
   return handle;
 }
 
@@ -989,9 +988,8 @@ void crocksdb_put_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                      crocksdb_column_family_handle_t* column_family,
                      const char* key, size_t keylen, const char* val,
                      size_t vallen, char** errptr) {
-  SaveError(errptr,
-            db->rep->Put(options->rep, column_family->rep, Slice(key, keylen),
-                         Slice(val, vallen)));
+  SaveError(errptr, db->rep->Put(options->rep, column_family->rep,
+                                 Slice(key, keylen), Slice(val, vallen)));
 }
 
 void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -1002,9 +1000,8 @@ void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
 void crocksdb_delete_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                         crocksdb_column_family_handle_t* column_family,
                         const char* key, size_t keylen, char** errptr) {
-  SaveError(
-      errptr,
-      db->rep->Delete(options->rep, column_family->rep, Slice(key, keylen)));
+  SaveError(errptr, db->rep->Delete(options->rep, column_family->rep,
+                                    Slice(key, keylen)));
 }
 
 void crocksdb_single_delete(crocksdb_t* db,
@@ -1017,9 +1014,8 @@ void crocksdb_single_delete_cf(crocksdb_t* db,
                                const crocksdb_writeoptions_t* options,
                                crocksdb_column_family_handle_t* column_family,
                                const char* key, size_t keylen, char** errptr) {
-  SaveError(errptr,
-            db->rep->SingleDelete(options->rep, column_family->rep,
-                                  Slice(key, keylen)));
+  SaveError(errptr, db->rep->SingleDelete(options->rep, column_family->rep,
+                                          Slice(key, keylen)));
 }
 
 void crocksdb_delete_range_cf(crocksdb_t* db,
@@ -1028,27 +1024,24 @@ void crocksdb_delete_range_cf(crocksdb_t* db,
                               const char* begin_key, size_t begin_keylen,
                               const char* end_key, size_t end_keylen,
                               char** errptr) {
-  SaveError(errptr,
-            db->rep->DeleteRange(options->rep, column_family->rep,
-                                 Slice(begin_key, begin_keylen),
-                                 Slice(end_key, end_keylen)));
+  SaveError(errptr, db->rep->DeleteRange(options->rep, column_family->rep,
+                                         Slice(begin_key, begin_keylen),
+                                         Slice(end_key, end_keylen)));
 }
 
 void crocksdb_merge(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                     const char* key, size_t keylen, const char* val,
                     size_t vallen, char** errptr) {
-  SaveError(
-      errptr,
-      db->rep->Merge(options->rep, Slice(key, keylen), Slice(val, vallen)));
+  SaveError(errptr, db->rep->Merge(options->rep, Slice(key, keylen),
+                                   Slice(val, vallen)));
 }
 
 void crocksdb_merge_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                        crocksdb_column_family_handle_t* column_family,
                        const char* key, size_t keylen, const char* val,
                        size_t vallen, char** errptr) {
-  SaveError(errptr,
-            db->rep->Merge(options->rep, column_family->rep, Slice(key, keylen),
-                           Slice(val, vallen)));
+  SaveError(errptr, db->rep->Merge(options->rep, column_family->rep,
+                                   Slice(key, keylen), Slice(val, vallen)));
 }
 
 void crocksdb_write(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -4274,9 +4267,8 @@ void crocksdb_sstfilewriter_delete_range(crocksdb_sstfilewriter_t* writer,
                                          size_t begin_keylen,
                                          const char* end_key, size_t end_keylen,
                                          char** errptr) {
-  SaveError(errptr,
-            writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
-                                     Slice(end_key, end_keylen)));
+  SaveError(errptr, writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
+                                             Slice(end_key, end_keylen)));
 }
 
 void crocksdb_sstfilewriter_finish(crocksdb_sstfilewriter_t* writer,
@@ -6132,11 +6124,10 @@ crocksdb_column_family_handle_t* ctitandb_create_column_family(
   // Blindly cast db into TitanDB.
   TitanDB* titan_db = reinterpret_cast<TitanDB*>(db->rep);
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr,
-            titan_db->CreateColumnFamily(
-                TitanCFDescriptor(std::string(column_family_name),
-                                  titan_column_family_options->rep),
-                &(handle->rep)));
+  SaveError(errptr, titan_db->CreateColumnFamily(
+                        TitanCFDescriptor(std::string(column_family_name),
+                                          titan_column_family_options->rep),
+                        &(handle->rep)));
   return handle;
 }
 
@@ -6435,9 +6426,8 @@ void ctitandb_delete_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                column_family->rep, &range, 1, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                        column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_files_in_ranges_cf(
@@ -6461,9 +6451,8 @@ void ctitandb_delete_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                        cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 void ctitandb_delete_blob_files_in_range(crocksdb_t* db, const char* start_key,
@@ -6491,9 +6480,8 @@ void ctitandb_delete_blob_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                column_family->rep, &range, 1, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                        column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_blob_files_in_ranges_cf(
@@ -6517,9 +6505,8 @@ void ctitandb_delete_blob_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr,
-            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                        cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 /* RocksDB Cloud */

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -954,9 +954,10 @@ crocksdb_column_family_handle_t* crocksdb_create_column_family(
     crocksdb_t* db, const crocksdb_options_t* column_family_options,
     const char* column_family_name, char** errptr) {
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr, db->rep->CreateColumnFamily(
-                        ColumnFamilyOptions(column_family_options->rep),
-                        std::string(column_family_name), &(handle->rep)));
+  SaveError(errptr,
+            db->rep->CreateColumnFamily(
+                ColumnFamilyOptions(column_family_options->rep),
+                std::string(column_family_name), &(handle->rep)));
   return handle;
 }
 
@@ -988,8 +989,9 @@ void crocksdb_put_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                      crocksdb_column_family_handle_t* column_family,
                      const char* key, size_t keylen, const char* val,
                      size_t vallen, char** errptr) {
-  SaveError(errptr, db->rep->Put(options->rep, column_family->rep,
-                                 Slice(key, keylen), Slice(val, vallen)));
+  SaveError(errptr,
+            db->rep->Put(options->rep, column_family->rep, Slice(key, keylen),
+                         Slice(val, vallen)));
 }
 
 void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -1000,8 +1002,9 @@ void crocksdb_delete(crocksdb_t* db, const crocksdb_writeoptions_t* options,
 void crocksdb_delete_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                         crocksdb_column_family_handle_t* column_family,
                         const char* key, size_t keylen, char** errptr) {
-  SaveError(errptr, db->rep->Delete(options->rep, column_family->rep,
-                                    Slice(key, keylen)));
+  SaveError(
+      errptr,
+      db->rep->Delete(options->rep, column_family->rep, Slice(key, keylen)));
 }
 
 void crocksdb_single_delete(crocksdb_t* db,
@@ -1014,8 +1017,9 @@ void crocksdb_single_delete_cf(crocksdb_t* db,
                                const crocksdb_writeoptions_t* options,
                                crocksdb_column_family_handle_t* column_family,
                                const char* key, size_t keylen, char** errptr) {
-  SaveError(errptr, db->rep->SingleDelete(options->rep, column_family->rep,
-                                          Slice(key, keylen)));
+  SaveError(errptr,
+            db->rep->SingleDelete(options->rep, column_family->rep,
+                                  Slice(key, keylen)));
 }
 
 void crocksdb_delete_range_cf(crocksdb_t* db,
@@ -1024,24 +1028,27 @@ void crocksdb_delete_range_cf(crocksdb_t* db,
                               const char* begin_key, size_t begin_keylen,
                               const char* end_key, size_t end_keylen,
                               char** errptr) {
-  SaveError(errptr, db->rep->DeleteRange(options->rep, column_family->rep,
-                                         Slice(begin_key, begin_keylen),
-                                         Slice(end_key, end_keylen)));
+  SaveError(errptr,
+            db->rep->DeleteRange(options->rep, column_family->rep,
+                                 Slice(begin_key, begin_keylen),
+                                 Slice(end_key, end_keylen)));
 }
 
 void crocksdb_merge(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                     const char* key, size_t keylen, const char* val,
                     size_t vallen, char** errptr) {
-  SaveError(errptr, db->rep->Merge(options->rep, Slice(key, keylen),
-                                   Slice(val, vallen)));
+  SaveError(
+      errptr,
+      db->rep->Merge(options->rep, Slice(key, keylen), Slice(val, vallen)));
 }
 
 void crocksdb_merge_cf(crocksdb_t* db, const crocksdb_writeoptions_t* options,
                        crocksdb_column_family_handle_t* column_family,
                        const char* key, size_t keylen, const char* val,
                        size_t vallen, char** errptr) {
-  SaveError(errptr, db->rep->Merge(options->rep, column_family->rep,
-                                   Slice(key, keylen), Slice(val, vallen)));
+  SaveError(errptr,
+            db->rep->Merge(options->rep, column_family->rep, Slice(key, keylen),
+                           Slice(val, vallen)));
 }
 
 void crocksdb_write(crocksdb_t* db, const crocksdb_writeoptions_t* options,
@@ -4119,9 +4126,25 @@ struct crocksdb_file_system_inspector_impl_t : public FileSystemInspector {
 
   virtual ~crocksdb_file_system_inspector_impl_t() { destructor(state); }
 
-  size_t Read(size_t len) { return read(state, len); }
+  Status Read(size_t len, size_t& allowed) {
+    char* err = nullptr;
+    allowed = read(state, len, &err);
+    if (err) {
+      return Status::IOError(err);
+    } else {
+      return Status::OK();
+    }
+  }
 
-  size_t Write(size_t len) { return write(state, len); }
+  Status Write(size_t len, size_t& allowed) {
+    char* err = nullptr;
+    allowed = write(state, len, &err);
+    if (err) {
+      return Status::IOError(err);
+    } else {
+      return Status::OK();
+    }
+  }
 };
 
 crocksdb_file_system_inspector_t* crocksdb_file_system_inspector_create(
@@ -4146,15 +4169,19 @@ void crocksdb_file_system_inspector_destroy(
 }
 
 size_t crocksdb_file_system_inspector_read(
-    crocksdb_file_system_inspector_t* inspector, size_t len) {
+    crocksdb_file_system_inspector_t* inspector, size_t len, char** errptr) {
   assert(inspector != nullptr && inspector->rep != nullptr);
-  return inspector->rep->Read(len);
+  size_t allowed = 0;
+  SaveError(errptr, inspector->rep->Read(len, allowed));
+  return allowed;
 }
 
 size_t crocksdb_file_system_inspector_write(
-    crocksdb_file_system_inspector_t* inspector, size_t len) {
+    crocksdb_file_system_inspector_t* inspector, size_t len, char** errptr) {
   assert(inspector != nullptr && inspector->rep != nullptr);
-  return inspector->rep->Write(len);
+  size_t allowed = 0;
+  SaveError(errptr, inspector->rep->Write(len, allowed));
+  return allowed;
 }
 
 crocksdb_env_t* crocksdb_file_system_inspected_create(
@@ -4247,8 +4274,9 @@ void crocksdb_sstfilewriter_delete_range(crocksdb_sstfilewriter_t* writer,
                                          size_t begin_keylen,
                                          const char* end_key, size_t end_keylen,
                                          char** errptr) {
-  SaveError(errptr, writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
-                                             Slice(end_key, end_keylen)));
+  SaveError(errptr,
+            writer->rep->DeleteRange(Slice(begin_key, begin_keylen),
+                                     Slice(end_key, end_keylen)));
 }
 
 void crocksdb_sstfilewriter_finish(crocksdb_sstfilewriter_t* writer,
@@ -6104,10 +6132,11 @@ crocksdb_column_family_handle_t* ctitandb_create_column_family(
   // Blindly cast db into TitanDB.
   TitanDB* titan_db = reinterpret_cast<TitanDB*>(db->rep);
   crocksdb_column_family_handle_t* handle = new crocksdb_column_family_handle_t;
-  SaveError(errptr, titan_db->CreateColumnFamily(
-                        TitanCFDescriptor(std::string(column_family_name),
-                                          titan_column_family_options->rep),
-                        &(handle->rep)));
+  SaveError(errptr,
+            titan_db->CreateColumnFamily(
+                TitanCFDescriptor(std::string(column_family_name),
+                                  titan_column_family_options->rep),
+                &(handle->rep)));
   return handle;
 }
 
@@ -6406,8 +6435,9 @@ void ctitandb_delete_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                        column_family->rep, &range, 1, include_end));
+  SaveError(errptr,
+            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_files_in_ranges_cf(
@@ -6431,8 +6461,9 @@ void ctitandb_delete_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
-                        cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr,
+            static_cast<TitanDB*>(db->rep)->DeleteFilesInRanges(
+                cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 void ctitandb_delete_blob_files_in_range(crocksdb_t* db, const char* start_key,
@@ -6460,8 +6491,9 @@ void ctitandb_delete_blob_files_in_range_cf(
       start_key ? (a = Slice(start_key, start_key_len), &a) : nullptr,
       limit_key ? (b = Slice(limit_key, limit_key_len), &b) : nullptr);
 
-  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                        column_family->rep, &range, 1, include_end));
+  SaveError(errptr,
+            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                column_family->rep, &range, 1, include_end));
 }
 
 void ctitandb_delete_blob_files_in_ranges_cf(
@@ -6485,8 +6517,9 @@ void ctitandb_delete_blob_files_in_ranges_cf(
     }
     ranges[i] = RangePtr(start, limit);
   }
-  SaveError(errptr, static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
-                        cf->rep, &ranges[0], num_ranges, include_end));
+  SaveError(errptr,
+            static_cast<TitanDB*>(db->rep)->DeleteBlobFilesInRanges(
+                cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 /* RocksDB Cloud */

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1647,9 +1647,11 @@ crocksdb_key_managed_encrypted_env_create(crocksdb_env_t*,
 /* FileSystemManagedEnv */
 
 typedef size_t (*crocksdb_file_system_inspector_read_cb)(void* state,
-                                                         size_t len);
+                                                         size_t len,
+                                                         char** errptr);
 typedef size_t (*crocksdb_file_system_inspector_write_cb)(void* state,
-                                                          size_t len);
+                                                          size_t len,
+                                                          char** errptr);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_file_system_inspector_t*
 crocksdb_file_system_inspector_create(
@@ -1659,9 +1661,9 @@ crocksdb_file_system_inspector_create(
 extern C_ROCKSDB_LIBRARY_API void crocksdb_file_system_inspector_destroy(
     crocksdb_file_system_inspector_t*);
 extern C_ROCKSDB_LIBRARY_API size_t crocksdb_file_system_inspector_read(
-    crocksdb_file_system_inspector_t* inspector, size_t len);
+    crocksdb_file_system_inspector_t* inspector, size_t len, char** errptr);
 extern C_ROCKSDB_LIBRARY_API size_t crocksdb_file_system_inspector_write(
-    crocksdb_file_system_inspector_t* inspector, size_t len);
+    crocksdb_file_system_inspector_t* inspector, size_t len, char** errptr);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
 crocksdb_file_system_inspected_create(crocksdb_env_t*,

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1644,7 +1644,7 @@ crocksdb_key_managed_encrypted_env_create(crocksdb_env_t*,
                                           crocksdb_encryption_key_manager_t*);
 #endif
 
-/* FileSystemManagedEnv */
+/* FileSystemInspectedEnv */
 
 typedef size_t (*crocksdb_file_system_inspector_read_cb)(void* state,
                                                          size_t len,
@@ -1666,8 +1666,8 @@ extern C_ROCKSDB_LIBRARY_API size_t crocksdb_file_system_inspector_write(
     crocksdb_file_system_inspector_t* inspector, size_t len, char** errptr);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
-crocksdb_file_system_inspected_create(crocksdb_env_t*,
-                                      crocksdb_file_system_inspector_t*);
+crocksdb_file_system_inspected_env_create(crocksdb_env_t*,
+                                          crocksdb_file_system_inspector_t*);
 
 /* SstFile */
 

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1647,10 +1647,8 @@ crocksdb_key_managed_encrypted_env_create(crocksdb_env_t*,
 /* FileSystemManagedEnv */
 
 typedef size_t (*crocksdb_file_system_inspector_read_cb)(void* state,
-                                                         int io_type,
                                                          size_t len);
 typedef size_t (*crocksdb_file_system_inspector_write_cb)(void* state,
-                                                          int io_type,
                                                           size_t len);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_file_system_inspector_t*
@@ -1661,9 +1659,9 @@ crocksdb_file_system_inspector_create(
 extern C_ROCKSDB_LIBRARY_API void crocksdb_file_system_inspector_destroy(
     crocksdb_file_system_inspector_t*);
 extern C_ROCKSDB_LIBRARY_API size_t crocksdb_file_system_inspector_read(
-    crocksdb_file_system_inspector_t* inspector, int io_type, size_t len);
+    crocksdb_file_system_inspector_t* inspector, size_t len);
 extern C_ROCKSDB_LIBRARY_API size_t crocksdb_file_system_inspector_write(
-    crocksdb_file_system_inspector_t* inspector, int io_type, size_t len);
+    crocksdb_file_system_inspector_t* inspector, size_t len);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
 crocksdb_file_system_inspected_create(crocksdb_env_t*,

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -214,6 +214,9 @@ typedef struct crocksdb_encryption_key_manager_t
     crocksdb_encryption_key_manager_t;
 #endif
 
+typedef struct crocksdb_file_system_inspector_t
+    crocksdb_file_system_inspector_t;
+
 /* DB operations */
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_t* crocksdb_open(
@@ -1640,6 +1643,31 @@ extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
 crocksdb_key_managed_encrypted_env_create(crocksdb_env_t*,
                                           crocksdb_encryption_key_manager_t*);
 #endif
+
+/* FileSystemManagedEnv */
+
+typedef size_t (*crocksdb_file_system_inspector_read_cb)(void* state,
+                                                         int io_type,
+                                                         size_t len);
+typedef size_t (*crocksdb_file_system_inspector_write_cb)(void* state,
+                                                          int io_type,
+                                                          size_t len);
+
+extern C_ROCKSDB_LIBRARY_API crocksdb_file_system_inspector_t*
+crocksdb_file_system_inspector_create(
+    void* state, void (*destructor)(void*),
+    crocksdb_file_system_inspector_read_cb read,
+    crocksdb_file_system_inspector_write_cb write);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_file_system_inspector_destroy(
+    crocksdb_file_system_inspector_t*);
+extern C_ROCKSDB_LIBRARY_API size_t crocksdb_file_system_inspector_read(
+    crocksdb_file_system_inspector_t* inspector, int io_type, size_t len);
+extern C_ROCKSDB_LIBRARY_API size_t crocksdb_file_system_inspector_write(
+    crocksdb_file_system_inspector_t* inspector, int io_type, size_t len);
+
+extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
+crocksdb_file_system_inspected_create(crocksdb_env_t*,
+                                      crocksdb_file_system_inspector_t*);
 
 /* SstFile */
 

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1740,13 +1740,11 @@ extern "C" {
     pub fn crocksdb_file_system_inspector_read(
         inspector: *mut DBFileSystemInspectorInstance,
         io_type: DBIOType,
-        offset: size_t,
         len: size_t,
     ) -> size_t;
     pub fn crocksdb_file_system_inspector_write(
         inspector: *mut DBFileSystemInspectorInstance,
         io_type: DBIOType,
-        offset: size_t,
         len: size_t,
     ) -> size_t;
 

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -465,14 +465,6 @@ pub enum CompactionFilterDecision {
     RemoveAndSkipUntil = 3,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(C)]
-pub enum DBIOType {
-    Uncategorized = 0,
-    Flush = 1,
-    Compaction = 2,
-}
-
 /// # Safety
 ///
 /// ptr must point to a valid CStr value

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1725,17 +1725,19 @@ extern "C" {
     pub fn crocksdb_file_system_inspector_create(
         state: *mut c_void,
         destructor: extern "C" fn(*mut c_void),
-        read: extern "C" fn(*mut c_void, size_t) -> size_t,
-        write: extern "C" fn(*mut c_void, size_t) -> size_t,
+        read: extern "C" fn(*mut c_void, size_t, *mut *mut c_char) -> size_t,
+        write: extern "C" fn(*mut c_void, size_t, *mut *mut c_char) -> size_t,
     ) -> *mut DBFileSystemInspectorInstance;
     pub fn crocksdb_file_system_inspector_destroy(inspector: *mut DBFileSystemInspectorInstance);
     pub fn crocksdb_file_system_inspector_read(
         inspector: *mut DBFileSystemInspectorInstance,
         len: size_t,
+        errptr: *mut *mut c_char,
     ) -> size_t;
     pub fn crocksdb_file_system_inspector_write(
         inspector: *mut DBFileSystemInspectorInstance,
         len: size_t,
+        errptr: *mut *mut c_char,
     ) -> size_t;
 
     pub fn crocksdb_file_system_inspected_env_create(

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1721,7 +1721,7 @@ extern "C" {
         key_manager: *mut DBEncryptionKeyManagerInstance,
     ) -> *mut DBEnv;
 
-    // FileSystemManagedEnv
+    // FileSystemInspectedEnv
     pub fn crocksdb_file_system_inspector_create(
         state: *mut c_void,
         destructor: extern "C" fn(*mut c_void),

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1733,18 +1733,16 @@ extern "C" {
     pub fn crocksdb_file_system_inspector_create(
         state: *mut c_void,
         destructor: extern "C" fn(*mut c_void),
-        read: extern "C" fn(*mut c_void, c_int, size_t) -> size_t,
-        write: extern "C" fn(*mut c_void, c_int, size_t) -> size_t,
+        read: extern "C" fn(*mut c_void, size_t) -> size_t,
+        write: extern "C" fn(*mut c_void, size_t) -> size_t,
     ) -> *mut DBFileSystemInspectorInstance;
     pub fn crocksdb_file_system_inspector_destroy(inspector: *mut DBFileSystemInspectorInstance);
     pub fn crocksdb_file_system_inspector_read(
         inspector: *mut DBFileSystemInspectorInstance,
-        io_type: DBIOType,
         len: size_t,
     ) -> size_t;
     pub fn crocksdb_file_system_inspector_write(
         inspector: *mut DBFileSystemInspectorInstance,
-        io_type: DBIOType,
         len: size_t,
     ) -> size_t;
 

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -173,6 +173,8 @@ pub struct DBSstPartitionerContext(c_void);
 pub struct DBSstPartitionerFactory(c_void);
 #[repr(C)]
 pub struct DBWriteBatchIterator(c_void);
+#[repr(C)]
+pub struct DBFileSystemInspectorInstance(c_void);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(C)]
@@ -461,6 +463,14 @@ pub enum CompactionFilterDecision {
     Remove = 1,
     ChangeValue = 2,
     RemoveAndSkipUntil = 3,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub enum DBIOType {
+    Uncategorized = 0,
+    Flush = 1,
+    Compaction = 2,
 }
 
 /// # Safety
@@ -1717,6 +1727,32 @@ extern "C" {
     pub fn crocksdb_key_managed_encrypted_env_create(
         base_env: *mut DBEnv,
         key_manager: *mut DBEncryptionKeyManagerInstance,
+    ) -> *mut DBEnv;
+
+    // FileSystemManagedEnv
+    pub fn crocksdb_file_system_inspector_create(
+        state: *mut c_void,
+        destructor: extern "C" fn(*mut c_void),
+        read: extern "C" fn(*mut c_void, c_int, size_t) -> size_t,
+        write: extern "C" fn(*mut c_void, c_int, size_t) -> size_t,
+    ) -> *mut DBFileSystemInspectorInstance;
+    pub fn crocksdb_file_system_inspector_destroy(inspector: *mut DBFileSystemInspectorInstance);
+    pub fn crocksdb_file_system_inspector_read(
+        inspector: *mut DBFileSystemInspectorInstance,
+        io_type: DBIOType,
+        offset: size_t,
+        len: size_t,
+    ) -> size_t;
+    pub fn crocksdb_file_system_inspector_write(
+        inspector: *mut DBFileSystemInspectorInstance,
+        io_type: DBIOType,
+        offset: size_t,
+        len: size_t,
+    ) -> size_t;
+
+    pub fn crocksdb_file_system_inspected_env_create(
+        base_env: *mut DBEnv,
+        inspector: *mut DBFileSystemInspectorInstance,
     ) -> *mut DBEnv;
 
     // SstFileReader

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -2,7 +2,6 @@
 
 pub use crocksdb_ffi::{
     self, DBEncryptionKeyManagerInstance, DBEncryptionMethod, DBFileEncryptionInfo,
-    DBFileSystemInspectorInstance,
 };
 
 use libc::{c_char, c_void, size_t};

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -2,6 +2,7 @@
 
 pub use crocksdb_ffi::{
     self, DBEncryptionKeyManagerInstance, DBEncryptionMethod, DBFileEncryptionInfo,
+    DBFileSystemInspectorInstance,
 };
 
 use libc::{c_char, c_void, size_t};
@@ -228,7 +229,7 @@ unsafe impl Sync for DBEncryptionKeyManager {}
 impl DBEncryptionKeyManager {
     pub fn new(key_manager: Arc<dyn EncryptionKeyManager>) -> DBEncryptionKeyManager {
         // Size of Arc<dyn T>::into_raw is of 128-bits, which couldn't be used as C-style pointer.
-        // Bixing it to make a 64-bits pointer.
+        // Boxing it to make a 64-bits pointer.
         let ctx = Box::into_raw(Box::new(key_manager)) as *mut c_void;
         let instance = unsafe {
             crocksdb_ffi::crocksdb_encryption_key_manager_create(

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -56,7 +56,7 @@ unsafe impl Sync for DBFileSystemInspector {}
 impl DBFileSystemInspector {
     pub fn new(file_system_inspector: Arc<dyn FileSystemInspector>) -> DBFileSystemInspector {
         // Size of Arc<dyn T>::into_raw is of 128-bits, which couldn't be used as C-style pointer.
-        // Bixing it to make a 64-bits pointer.
+        // Boxing it to make a 64-bits pointer.
         let ctx = Box::into_raw(Box::new(file_system_inspector)) as *mut c_void;
         let instance = unsafe {
             crocksdb_ffi::crocksdb_file_system_inspector_create(

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -2,13 +2,13 @@
 
 pub use crocksdb_ffi::{self, DBFileSystemInspectorInstance, DBIOType};
 
-use libc::{c_int, c_void, size_t};
+use libc::{c_void, size_t};
 use std::sync::Arc;
 
 // Inspect global IO flow. No per-file inspection for now.
 pub trait FileSystemInspector: Sync + Send {
-    fn read(&self, io_type: DBIOType, len: usize) -> usize;
-    fn write(&self, io_type: DBIOType, len: usize) -> usize;
+    fn read(&self, len: usize) -> usize;
+    fn write(&self, len: usize) -> usize;
 }
 
 extern "C" fn file_system_inspector_destructor(ctx: *mut c_void) {
@@ -18,32 +18,14 @@ extern "C" fn file_system_inspector_destructor(ctx: *mut c_void) {
     }
 }
 
-extern "C" fn file_system_inspector_read(
-    ctx: *mut c_void,
-    raw_io_type: c_int,
-    len: size_t,
-) -> size_t {
+extern "C" fn file_system_inspector_read(ctx: *mut c_void, len: size_t) -> size_t {
     let file_system_inspector = unsafe { &*(ctx as *mut Arc<dyn FileSystemInspector>) };
-    let io_type = match raw_io_type {
-        1 => DBIOType::Flush,
-        2 => DBIOType::Compaction,
-        _ => DBIOType::Uncategorized,
-    };
-    return file_system_inspector.read(io_type, len);
+    return file_system_inspector.read(len);
 }
 
-extern "C" fn file_system_inspector_write(
-    ctx: *mut c_void,
-    raw_io_type: c_int,
-    len: size_t,
-) -> size_t {
+extern "C" fn file_system_inspector_write(ctx: *mut c_void, len: size_t) -> size_t {
     let file_system_inspector = unsafe { &*(ctx as *mut Arc<dyn FileSystemInspector>) };
-    let io_type = match raw_io_type {
-        1 => DBIOType::Flush,
-        2 => DBIOType::Compaction,
-        _ => DBIOType::Uncategorized,
-    };
-    return file_system_inspector.write(io_type, len);
+    return file_system_inspector.write(len);
 }
 
 pub struct DBFileSystemInspector {
@@ -80,17 +62,17 @@ impl Drop for DBFileSystemInspector {
 
 #[cfg(test)]
 impl FileSystemInspector for DBFileSystemInspector {
-    fn read(&self, io_type: DBIOType, len: usize) -> usize {
+    fn read(&self, len: usize) -> usize {
         let ret: usize;
         unsafe {
-            ret = crocksdb_ffi::crocksdb_file_system_inspector_read(self.inner, io_type, len);
+            ret = crocksdb_ffi::crocksdb_file_system_inspector_read(self.inner, len);
         }
         ret
     }
-    fn write(&self, io_type: DBIOType, len: usize) -> usize {
+    fn write(&self, len: usize) -> usize {
         let ret: usize;
         unsafe {
-            ret = crocksdb_ffi::crocksdb_file_system_inspector_write(self.inner, io_type, len);
+            ret = crocksdb_ffi::crocksdb_file_system_inspector_write(self.inner, len);
         }
         ret
     }

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -88,7 +88,7 @@ impl Drop for DBFileSystemInspector {
 impl FileSystemInspector for DBFileSystemInspector {
     fn read(&self, len: usize) -> Result<usize, String> {
         let ret = unsafe {
-            ffi_try!(crocksdb_ffi::crocksdb_file_system_inspector_read(
+            ffi_try!(crocksdb_file_system_inspector_read(
                 self.inner, len
             ))
         };
@@ -96,7 +96,7 @@ impl FileSystemInspector for DBFileSystemInspector {
     }
     fn write(&self, len: usize) -> Result<usize, String> {
         let ret = unsafe {
-            ffi_try!(crocksdb_ffi::crocksdb_file_system_inspector_write(
+            ffi_try!(crocksdb_file_system_inspector_write(
                 self.inner, len
             ))
         };
@@ -106,7 +106,6 @@ impl FileSystemInspector for DBFileSystemInspector {
 
 #[cfg(test)]
 mod test {
-    use std::io::{Error, ErrorKind};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
@@ -147,7 +146,7 @@ mod test {
             if len <= inner.refill_bytes {
                 Ok(len)
             } else {
-                Err("request exceeds refill bytes");
+                Err("request exceeds refill bytes".into())
             }
         }
         fn write(&self, len: usize) -> Result<usize, String> {
@@ -156,7 +155,7 @@ mod test {
             if len <= inner.refill_bytes {
                 Ok(len)
             } else {
-                Err("request exceeds refill bytes");
+                Err("request exceeds refill bytes".into())
             }
         }
     }

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -87,19 +87,11 @@ impl Drop for DBFileSystemInspector {
 #[cfg(test)]
 impl FileSystemInspector for DBFileSystemInspector {
     fn read(&self, len: usize) -> Result<usize, String> {
-        let ret = unsafe {
-            ffi_try!(crocksdb_file_system_inspector_read(
-                self.inner, len
-            ))
-        };
+        let ret = unsafe { ffi_try!(crocksdb_file_system_inspector_read(self.inner, len)) };
         Ok(ret)
     }
     fn write(&self, len: usize) -> Result<usize, String> {
-        let ret = unsafe {
-            ffi_try!(crocksdb_file_system_inspector_write(
-                self.inner, len
-            ))
-        };
+        let ret = unsafe { ffi_try!(crocksdb_file_system_inspector_write(self.inner, len)) };
         Ok(ret)
     }
 }
@@ -141,7 +133,7 @@ mod test {
 
     impl FileSystemInspector for Mutex<TestFileSystemInspector> {
         fn read(&self, len: usize) -> Result<usize, String> {
-            let inner = self.lock().unwrap();
+            let mut inner = self.lock().unwrap();
             inner.read_called += 1;
             if len <= inner.refill_bytes {
                 Ok(len)
@@ -150,7 +142,7 @@ mod test {
             }
         }
         fn write(&self, len: usize) -> Result<usize, String> {
-            let inner = self.lock().unwrap();
+            let mut inner = self.lock().unwrap();
             inner.write_called += 1;
             if len <= inner.refill_bytes {
                 Ok(len)

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -1,0 +1,97 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+pub use crocksdb_ffi::{self, DBFileSystemInspectorInstance, DBIOType};
+
+use libc::{c_int, c_void, size_t};
+use std::sync::Arc;
+
+// Inspect global IO flow. No per-file inspection for now.
+pub trait FileSystemInspector: Sync + Send {
+    fn read(&self, io_type: DBIOType, len: usize) -> usize;
+    fn write(&self, io_type: DBIOType, len: usize) -> usize;
+}
+
+extern "C" fn file_system_inspector_destructor(ctx: *mut c_void) {
+    unsafe {
+        // Recover from raw pointer and implicitly drop.
+        Box::from_raw(ctx as *mut Arc<dyn FileSystemInspector>);
+    }
+}
+
+extern "C" fn file_system_inspector_read(
+    ctx: *mut c_void,
+    raw_io_type: c_int,
+    len: size_t,
+) -> size_t {
+    let file_system_inspector = unsafe { &*(ctx as *mut Arc<dyn FileSystemInspector>) };
+    let io_type = match raw_io_type {
+        1 => DBIOType::Flush,
+        2 => DBIOType::Compaction,
+        _ => DBIOType::Uncategorized,
+    };
+    return file_system_inspector.read(io_type, len);
+}
+
+extern "C" fn file_system_inspector_write(
+    ctx: *mut c_void,
+    raw_io_type: c_int,
+    len: size_t,
+) -> size_t {
+    let file_system_inspector = unsafe { &*(ctx as *mut Arc<dyn FileSystemInspector>) };
+    let io_type = match raw_io_type {
+        1 => DBIOType::Flush,
+        2 => DBIOType::Compaction,
+        _ => DBIOType::Uncategorized,
+    };
+    return file_system_inspector.write(io_type, len);
+}
+
+pub struct DBFileSystemInspector {
+    pub inner: *mut DBFileSystemInspectorInstance,
+}
+
+unsafe impl Send for DBFileSystemInspector {}
+unsafe impl Sync for DBFileSystemInspector {}
+
+impl DBFileSystemInspector {
+    pub fn new(file_system_inspector: Arc<dyn FileSystemInspector>) -> DBFileSystemInspector {
+        // Size of Arc<dyn T>::into_raw is of 128-bits, which couldn't be used as C-style pointer.
+        // Bixing it to make a 64-bits pointer.
+        let ctx = Box::into_raw(Box::new(file_system_inspector)) as *mut c_void;
+        let instance = unsafe {
+            crocksdb_ffi::crocksdb_file_system_inspector_create(
+                ctx,
+                file_system_inspector_destructor,
+                file_system_inspector_read,
+                file_system_inspector_write,
+            )
+        };
+        DBFileSystemInspector { inner: instance }
+    }
+}
+
+impl Drop for DBFileSystemInspector {
+    fn drop(&mut self) {
+        unsafe {
+            crocksdb_ffi::crocksdb_file_system_inspector_destroy(self.inner);
+        }
+    }
+}
+
+#[cfg(test)]
+impl FileSystemInspector for DBFileSystemInspector {
+    fn read(&self, io_type: DBIOType, len: usize) -> usize {
+        let ret: usize;
+        unsafe {
+            ret = crocksdb_ffi::crocksdb_file_system_inspector_read(self.inner, io_type, len);
+        }
+        ret
+    }
+    fn write(&self, io_type: DBIOType, len: usize) -> usize {
+        let ret: usize;
+        unsafe {
+            ret = crocksdb_ffi::crocksdb_file_system_inspector_write(self.inner, io_type, len);
+        }
+        ret
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub mod comparator;
 #[cfg(feature = "encryption")]
 mod encryption;
 mod event_listener;
+mod file_system;
 pub mod logger;
 pub mod merge_operator;
 mod metadata;

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -42,6 +42,7 @@ use std::{fs, ptr, slice};
 use cloud::CloudEnvOptions;
 #[cfg(feature = "encryption")]
 use encryption::{DBEncryptionKeyManager, EncryptionKeyManager};
+use file_system::{DBFileSystemInspector, FileSystemInspector};
 use table_properties::{TableProperties, TablePropertiesCollection};
 use table_properties_rc::TablePropertiesCollection as RcTablePropertiesCollection;
 use titan::TitanDBOptions;
@@ -2651,6 +2652,23 @@ impl Env {
             crocksdb_ffi::crocksdb_key_managed_encrypted_env_create(
                 base_env.inner,
                 db_key_manager.inner,
+            )
+        };
+        Ok(Env {
+            inner: env,
+            base: Some(base_env),
+        })
+    }
+
+    pub fn new_file_system_inspected_env(
+        base_env: Arc<Env>,
+        file_system_inspector: Arc<dyn FileSystemInspector>,
+    ) -> Result<Env, String> {
+        let db_file_system_inspector = DBFileSystemInspector::new(file_system_inspector);
+        let env = unsafe {
+            crocksdb_ffi::crocksdb_file_system_inspected_env_create(
+                base_env.inner,
+                db_file_system_inspector.inner,
             )
         };
         Ok(Env {


### PR DESCRIPTION
Followup on tikv/rocksdb#216, port related interface to rust, add `file_system_inspected_env` factory method.

Signed-off-by: tabokie <xy.tao@outlook.com>