### PR TITLE
rocksdb: Atomize RenameFile in KeyManagedEncryptedEnv

### DIFF
--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1615,7 +1615,6 @@ extern C_ROCKSDB_LIBRARY_API const char*
 crocksdb_encryption_key_manager_link_file(
     crocksdb_encryption_key_manager_t* key_manager, const char* src_fname,
     const char* dst_fname);
-extern C_ROCKSDB_LIBRARY_API const char*
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
 crocksdb_key_managed_encrypted_env_create(crocksdb_env_t*,

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1590,8 +1590,6 @@ typedef const char* (*crocksdb_encryption_key_manager_delete_file_cb)(
     void* state, const char* fname);
 typedef const char* (*crocksdb_encryption_key_manager_link_file_cb)(
     void* state, const char* src_fname, const char* dst_fname);
-typedef const char* (*crocksdb_encryption_key_manager_rename_file_cb)(
-    void* state, const char* src_fname, const char* dst_fname);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_encryption_key_manager_t*
 crocksdb_encryption_key_manager_create(
@@ -1599,8 +1597,7 @@ crocksdb_encryption_key_manager_create(
     crocksdb_encryption_key_manager_get_file_cb get_file,
     crocksdb_encryption_key_manager_new_file_cb new_file,
     crocksdb_encryption_key_manager_delete_file_cb delete_file,
-    crocksdb_encryption_key_manager_link_file_cb link_file,
-    crocksdb_encryption_key_manager_rename_file_cb rename_file);
+    crocksdb_encryption_key_manager_link_file_cb link_file);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_encryption_key_manager_destroy(
     crocksdb_encryption_key_manager_t*);
 extern C_ROCKSDB_LIBRARY_API const char*
@@ -1619,9 +1616,6 @@ crocksdb_encryption_key_manager_link_file(
     crocksdb_encryption_key_manager_t* key_manager, const char* src_fname,
     const char* dst_fname);
 extern C_ROCKSDB_LIBRARY_API const char*
-crocksdb_encryption_key_manager_rename_file(
-    crocksdb_encryption_key_manager_t* key_manager, const char* src_fname,
-    const char* dst_fname);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
 crocksdb_key_managed_encrypted_env_create(crocksdb_env_t*,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1681,7 +1681,6 @@ extern "C" {
         ) -> *const c_char,
         delete_file: extern "C" fn(*mut c_void, *const c_char) -> *const c_char,
         link_file: extern "C" fn(*mut c_void, *const c_char, *const c_char) -> *const c_char,
-        rename_file: extern "C" fn(*mut c_void, *const c_char, *const c_char) -> *const c_char,
     ) -> *mut DBEncryptionKeyManagerInstance;
     #[cfg(feature = "encryption")]
     pub fn crocksdb_encryption_key_manager_destroy(
@@ -1706,12 +1705,6 @@ extern "C" {
     ) -> *const c_char;
     #[cfg(feature = "encryption")]
     pub fn crocksdb_encryption_key_manager_link_file(
-        key_manager: *mut DBEncryptionKeyManagerInstance,
-        src_fname: *const c_char,
-        dst_fname: *const c_char,
-    ) -> *const c_char;
-    #[cfg(feature = "encryption")]
-    pub fn crocksdb_encryption_key_manager_rename_file(
         key_manager: *mut DBEncryptionKeyManagerInstance,
         src_fname: *const c_char,
         dst_fname: *const c_char,


### PR DESCRIPTION
1. update rocksdb to atomize `RenameFile` in `KeyManagedEncryptedEnv`
2. removed redundant rename logic from key manager