### PR TITLE
use `uname -m` instead of `uname -p` to get the architecture

### DIFF
--- a/scripts/generate-bindings.sh
+++ b/scripts/generate-bindings.sh
@@ -6,7 +6,7 @@
 
 export UPDATE_BIND=1
 if [ "$ARCH" == "" ]; then
-    ARCH=`uname -p`
+    ARCH=`uname -m`
 fi
 cargo build  --target ${ARCH}-unknown-linux-gnu
 rustfmt librocksdb_sys/bindings/*


### PR DESCRIPTION
`uname -p` returns `AMD Ryzen 7 3700X 8-Core Processor` in my PC. `uname -m` seems to be a better idea on getting the architecture.

Or simply `arch` command works well, but I don't know whether it exists on non-linux system.