### PR TITLE
refactor usage of `Arc`

### DIFF
--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -192,7 +192,7 @@ unsafe impl Send for DBEncryptionKeyManager {}
 unsafe impl Sync for DBEncryptionKeyManager {}
 
 impl DBEncryptionKeyManager {
-    pub fn new<T: EncryptionKeyManager>(key_manager: T>) -> DBEncryptionKeyManager {
+    pub fn new<T: EncryptionKeyManager>(key_manager: T) -> DBEncryptionKeyManager {
         let ctx = Box::into_raw(Box::new(key_manager)) as *mut c_void;
         let instance = unsafe {
             crocksdb_ffi::crocksdb_encryption_key_manager_create(

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -81,7 +81,7 @@ extern "C" fn encryption_key_manager_get_file(
     fname: *const c_char,
     file_info: *mut DBFileEncryptionInfo,
 ) -> *const c_char {
-    let key_manager = unsafe { Box::from_raw(ctx as *mut Box<dyn EncryptionKeyManager>) };
+    let key_manager = unsafe { &*(ctx as *mut Box<dyn EncryptionKeyManager>) };
     let fname = match unsafe { CStr::from_ptr(fname).to_str() } {
         Ok(ret) => ret,
         Err(err) => {
@@ -107,7 +107,7 @@ extern "C" fn encryption_key_manager_new_file(
     fname: *const c_char,
     file_info: *mut DBFileEncryptionInfo,
 ) -> *const c_char {
-    let key_manager = unsafe { Box::from_raw(ctx as *mut Box<dyn EncryptionKeyManager>) };
+    let key_manager = unsafe { &*(ctx as *mut Box<dyn EncryptionKeyManager>) };
     let fname = match unsafe { CStr::from_ptr(fname).to_str() } {
         Ok(ret) => ret,
         Err(err) => {
@@ -132,7 +132,7 @@ extern "C" fn encryption_key_manager_delete_file(
     ctx: *mut c_void,
     fname: *const c_char,
 ) -> *const c_char {
-    let key_manager = unsafe { Box::from_raw(ctx as *mut Box<dyn EncryptionKeyManager>) };
+    let key_manager = unsafe { &*(ctx as *mut Box<dyn EncryptionKeyManager>) };
     let fname = match unsafe { CStr::from_ptr(fname).to_str() } {
         Ok(ret) => ret,
         Err(err) => {
@@ -156,7 +156,7 @@ extern "C" fn encryption_key_manager_link_file(
     src_fname: *const c_char,
     dst_fname: *const c_char,
 ) -> *const c_char {
-    let key_manager = unsafe { Box::from_raw(ctx as *mut Box<dyn EncryptionKeyManager>) };
+    let key_manager = unsafe { &*(ctx as *mut Box<dyn EncryptionKeyManager>) };
     let src_fname = match unsafe { CStr::from_ptr(src_fname).to_str() } {
         Ok(ret) => ret,
         Err(err) => {

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -197,11 +197,11 @@ impl DBEncryptionKeyManager {
         let instance = unsafe {
             crocksdb_ffi::crocksdb_encryption_key_manager_create(
                 ctx,
-                encryption_key_manager_destructor<T>,
-                encryption_key_manager_get_file<T>,
-                encryption_key_manager_new_file<T>,
-                encryption_key_manager_delete_file<T>,
-                encryption_key_manager_link_file<T>,
+                encryption_key_manager_destructor::<T>,
+                encryption_key_manager_get_file::<T>,
+                encryption_key_manager_new_file::<T>,
+                encryption_key_manager_delete_file::<T>,
+                encryption_key_manager_link_file::<T>,
             )
         };
         DBEncryptionKeyManager { inner: instance }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -192,10 +192,8 @@ unsafe impl Send for DBEncryptionKeyManager {}
 unsafe impl Sync for DBEncryptionKeyManager {}
 
 impl DBEncryptionKeyManager {
-    pub fn new(key_manager: Arc<dyn EncryptionKeyManager>) -> DBEncryptionKeyManager {
-        // Size of Arc<dyn T>::into_raw is of 128-bits, which couldn't be used as C-style pointer.
-        // Boxing it to make a 64-bits pointer.
-        let ctx = Box::into_raw(Box::new(key_manager)) as *mut c_void;
+    pub fn new(key_manager: Box<dyn EncryptionKeyManager>) -> DBEncryptionKeyManager {
+        let ctx = Box::into_raw(key_manager) as *mut c_void;
         let instance = unsafe {
             crocksdb_ffi::crocksdb_encryption_key_manager_create(
                 ctx,

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -69,7 +69,7 @@ fn copy_error<T: Into<Vec<u8>>>(err: T) -> *const c_char {
     unsafe { libc::strdup(cstr.as_ptr()) }
 }
 
-extern "C" fn encryption_key_manager_destructor(ctx: *mut c_void)<T: EncryptionKeyManager> {
+extern "C" fn encryption_key_manager_destructor<T: EncryptionKeyManager>(ctx: *mut c_void) {
     unsafe {
         // Recover from raw pointer and implicitly drop.
         Box::from_raw(ctx as *mut T);
@@ -156,7 +156,7 @@ extern "C" fn encryption_key_manager_link_file<T: EncryptionKeyManager>(
     src_fname: *const c_char,
     dst_fname: *const c_char,
 ) -> *const c_char {
-    let key_manager = unsafe { &*(ctx as *mut T>) };
+    let key_manager = unsafe { &*(ctx as *mut T) };
     let src_fname = match unsafe { CStr::from_ptr(src_fname).to_str() } {
         Ok(ret) => ret,
         Err(err) => {

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -129,7 +129,7 @@ mod test {
         }
     }
 
-    impl FileSystemInspector for Mutex<TestFileSystemInspector> {
+    impl FileSystemInspector for Arc<Mutex<TestFileSystemInspector>> {
         fn read(&self, len: usize) -> Result<usize, String> {
             let mut inner = self.lock().unwrap();
             inner.read_called += 1;
@@ -159,7 +159,7 @@ mod test {
             }),
             ..Default::default()
         }));
-        let db_fs_inspector = DBFileSystemInspector::new(fs_inspector.clone());
+        let db_fs_inspector = DBFileSystemInspector::new(Box::new(fs_inspector.clone());
         drop(fs_inspector);
         assert_eq!(0, drop_called.load(Ordering::SeqCst));
         drop(db_fs_inspector);
@@ -172,7 +172,7 @@ mod test {
             refill_bytes: 4,
             ..Default::default()
         }));
-        let db_fs_inspector = DBFileSystemInspector::new(fs_inspector.clone());
+        let db_fs_inspector = DBFileSystemInspector::new(Box::new(fs_inspector.clone());
         assert_eq!(2, db_fs_inspector.read(2).unwrap());
         assert!(db_fs_inspector.read(8).is_err());
         assert_eq!(2, db_fs_inspector.write(2).unwrap());

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -159,7 +159,7 @@ mod test {
             }),
             ..Default::default()
         }));
-        let db_fs_inspector = DBFileSystemInspector::new(Box::new(fs_inspector.clone());
+        let db_fs_inspector = DBFileSystemInspector::new(Box::new(fs_inspector.clone()));
         drop(fs_inspector);
         assert_eq!(0, drop_called.load(Ordering::SeqCst));
         drop(db_fs_inspector);
@@ -172,7 +172,7 @@ mod test {
             refill_bytes: 4,
             ..Default::default()
         }));
-        let db_fs_inspector = DBFileSystemInspector::new(Box::new(fs_inspector.clone());
+        let db_fs_inspector = DBFileSystemInspector::new(Box::new(fs_inspector.clone()));
         assert_eq!(2, db_fs_inspector.read(2).unwrap());
         assert!(db_fs_inspector.read(8).is_err());
         assert_eq!(2, db_fs_inspector.write(2).unwrap());

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -64,9 +64,9 @@ impl DBFileSystemInspector {
         let instance = unsafe {
             crocksdb_ffi::crocksdb_file_system_inspector_create(
                 ctx,
-                file_system_inspector_destructor<T>,
-                file_system_inspector_read<T>,
-                file_system_inspector_write<T>,
+                file_system_inspector_destructor::<T>,
+                file_system_inspector_read::<T>,
+                file_system_inspector_write::<T>,
             )
         };
         DBFileSystemInspector { inner: instance }

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -3,7 +3,6 @@
 pub use crocksdb_ffi::{self, DBFileSystemInspectorInstance};
 
 use libc::{c_char, c_void, size_t, strdup};
-use std::sync::Arc;
 
 // Inspect global IO flow. No per-file inspection for now.
 pub trait FileSystemInspector: Sync + Send {
@@ -23,7 +22,7 @@ extern "C" fn file_system_inspector_read(
     len: size_t,
     errptr: *mut *mut c_char,
 ) -> size_t {
-    let file_system_inspector = unsafe { Box::from_raw(ctx as *mut Box<dyn FileSystemInspector>) };
+    let file_system_inspector = unsafe { &*(ctx as *mut Box<dyn FileSystemInspector>) };
     match file_system_inspector.read(len) {
         Ok(ret) => ret,
         Err(e) => {
@@ -40,7 +39,7 @@ extern "C" fn file_system_inspector_write(
     len: size_t,
     errptr: *mut *mut c_char,
 ) -> size_t {
-    let file_system_inspector = unsafe { Box::from_raw(ctx as *mut Box<dyn FileSystemInspector>) };
+    let file_system_inspector = unsafe { &*(ctx as *mut Box<dyn FileSystemInspector>) };
     match file_system_inspector.write(len) {
         Ok(ret) => ret,
         Err(e) => {

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -60,10 +60,8 @@ unsafe impl Send for DBFileSystemInspector {}
 unsafe impl Sync for DBFileSystemInspector {}
 
 impl DBFileSystemInspector {
-    pub fn new(file_system_inspector: Arc<dyn FileSystemInspector>) -> DBFileSystemInspector {
-        // Size of Arc<dyn T>::into_raw is of 128-bits, which couldn't be used as C-style pointer.
-        // Boxing it to make a 64-bits pointer.
-        let ctx = Box::into_raw(Box::new(file_system_inspector)) as *mut c_void;
+    pub fn new(file_system_inspector: Box<dyn FileSystemInspector>) -> DBFileSystemInspector {
+        let ctx = Box::into_raw(file_system_inspector) as *mut c_void;
         let instance = unsafe {
             crocksdb_ffi::crocksdb_file_system_inspector_create(
                 ctx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub use compaction_filter::{
 };
 #[cfg(feature = "encryption")]
 pub use encryption::{DBEncryptionMethod, EncryptionKeyManager, FileEncryptionInfo};
+pub use file_system::FileSystemInspector;
 pub use event_listener::{
     CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo, SubcompactionJobInfo,
     WriteStallInfo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,11 +37,11 @@ pub use compaction_filter::{
 };
 #[cfg(feature = "encryption")]
 pub use encryption::{DBEncryptionMethod, EncryptionKeyManager, FileEncryptionInfo};
-pub use file_system::FileSystemInspector;
 pub use event_listener::{
     CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo, SubcompactionJobInfo,
     WriteStallInfo,
 };
+pub use file_system::FileSystemInspector;
 pub use librocksdb_sys::{
     self as crocksdb_ffi, new_bloom_filter, CompactionPriority, CompactionReason,
     DBBackgroundErrorReason, DBBottommostLevelCompaction, DBCompactionStyle, DBCompressionType,

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2656,7 +2656,7 @@ impl Env {
     #[cfg(feature = "encryption")]
     pub fn new_key_managed_encrypted_env(
         base_env: Arc<Env>,
-        key_manager: Arc<dyn EncryptionKeyManager>,
+        key_manager: Box<dyn EncryptionKeyManager>,
     ) -> Result<Env, String> {
         let db_key_manager = DBEncryptionKeyManager::new(key_manager);
         let env = unsafe {
@@ -2673,7 +2673,7 @@ impl Env {
 
     pub fn new_file_system_inspected_env(
         base_env: Arc<Env>,
-        file_system_inspector: Arc<dyn FileSystemInspector>,
+        file_system_inspector: Box<dyn FileSystemInspector>,
     ) -> Result<Env, String> {
         let db_file_system_inspector = DBFileSystemInspector::new(file_system_inspector);
         let env = unsafe {

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2671,7 +2671,7 @@ impl Env {
         })
     }
 
-    pub fn new_file_system_inspected_env<T: EncryptionKeyManager>(
+    pub fn new_file_system_inspected_env<T: FileSystemInspector>(
         base_env: Arc<Env>,
         file_system_inspector: T,
     ) -> Result<Env, String> {

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2654,9 +2654,9 @@ impl Env {
 
     // Create an encrypted env that accepts an external key manager.
     #[cfg(feature = "encryption")]
-    pub fn new_key_managed_encrypted_env(
+    pub fn new_key_managed_encrypted_env<T: EncryptionKeyManager>(
         base_env: Arc<Env>,
-        key_manager: Box<dyn EncryptionKeyManager>,
+        key_manager: T,
     ) -> Result<Env, String> {
         let db_key_manager = DBEncryptionKeyManager::new(key_manager);
         let env = unsafe {
@@ -2671,9 +2671,9 @@ impl Env {
         })
     }
 
-    pub fn new_file_system_inspected_env(
+    pub fn new_file_system_inspected_env<T: EncryptionKeyManager>(
         base_env: Arc<Env>,
-        file_system_inspector: Box<dyn FileSystemInspector>,
+        file_system_inspector: T,
     ) -> Result<Env, String> {
         let db_file_system_inspector = DBFileSystemInspector::new(file_system_inspector);
         let env = unsafe {


### PR DESCRIPTION
Accept boxed construct instead of `Arc` to avoid nested arc required to bridge different crates. Also fix a missing export.

Signed-off-by: tabokie <xy.tao@outlook.com>