### PR TITLE
Update bzip2-sys in order to use "static" feature

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 links = "rocksdb"
 
 [dependencies]
-bzip2-sys = "0.1.8+1.0.8" 
+bzip2-sys = { version = "0.1.11+1.0.8", features = ["static"] }
 libc = "0.2.11"
 libtitan_sys = { path = "libtitan_sys" }
 libz-sys = { version = "1.1", features = ["static"] }


### PR DESCRIPTION
Due to https://github.com/alexcrichton/bzip2-rs/pull/58 `bzip2-sys` versions above 0.1.8 do not guarantee that bzip2 is statically linked.
Which in turn causes the build to fail depending if pkg-config says bzip2 is available.