### PR TITLE
Allow setting write_global_seqno option

### DIFF
--- a/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/librocksdb_sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -3,14 +3,14 @@
 pub const __GNUC_VA_LIST: u32 = 1;
 pub const _STDINT_H: u32 = 1;
 pub const _FEATURES_H: u32 = 1;
-pub const _BSD_SOURCE: u32 = 1;
-pub const _SVID_SOURCE: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
 pub const __USE_ISOC11: u32 = 1;
 pub const __USE_ISOC99: u32 = 1;
 pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
 pub const _POSIX_SOURCE: u32 = 1;
 pub const _POSIX_C_SOURCE: u32 = 200809;
-pub const __USE_POSIX_IMPLICITLY: u32 = 1;
 pub const __USE_POSIX: u32 = 1;
 pub const __USE_POSIX2: u32 = 1;
 pub const __USE_POSIX199309: u32 = 1;
@@ -19,23 +19,42 @@ pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
 pub const __USE_MISC: u32 = 1;
-pub const __USE_BSD: u32 = 1;
-pub const __USE_SVID: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
-pub const __STDC_ISO_10646__: u32 = 201103;
-pub const __STDC_NO_THREADS__: u32 = 1;
+pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 18;
+pub const __GLIBC_MINOR__: u32 = 31;
 pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __WORDSIZE: u32 = 64;
 pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
 pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const __TIMESIZE: u32 = 64;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
 pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
 pub const INT8_MIN: i32 = -128;
 pub const INT16_MIN: i32 = -32768;
 pub const INT32_MIN: i32 = -2147483648;
@@ -122,14 +141,103 @@ fn bindgen_test_layout_max_align_t() {
         )
     );
 }
-pub type int_least8_t = libc::c_schar;
-pub type int_least16_t = libc::c_short;
-pub type int_least32_t = libc::c_int;
-pub type int_least64_t = libc::c_long;
-pub type uint_least8_t = libc::c_uchar;
-pub type uint_least16_t = libc::c_ushort;
-pub type uint_least32_t = libc::c_uint;
-pub type uint_least64_t = libc::c_ulong;
+pub type __u_char = libc::c_uchar;
+pub type __u_short = libc::c_ushort;
+pub type __u_int = libc::c_uint;
+pub type __u_long = libc::c_ulong;
+pub type __int8_t = libc::c_schar;
+pub type __uint8_t = libc::c_uchar;
+pub type __int16_t = libc::c_short;
+pub type __uint16_t = libc::c_ushort;
+pub type __int32_t = libc::c_int;
+pub type __uint32_t = libc::c_uint;
+pub type __int64_t = libc::c_long;
+pub type __uint64_t = libc::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = libc::c_long;
+pub type __u_quad_t = libc::c_ulong;
+pub type __intmax_t = libc::c_long;
+pub type __uintmax_t = libc::c_ulong;
+pub type __dev_t = libc::c_ulong;
+pub type __uid_t = libc::c_uint;
+pub type __gid_t = libc::c_uint;
+pub type __ino_t = libc::c_ulong;
+pub type __ino64_t = libc::c_ulong;
+pub type __mode_t = libc::c_uint;
+pub type __nlink_t = libc::c_ulong;
+pub type __off_t = libc::c_long;
+pub type __off64_t = libc::c_long;
+pub type __pid_t = libc::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [libc::c_int; 2usize],
+}
+#[test]
+fn bindgen_test_layout___fsid_t() {
+    assert_eq!(
+        ::std::mem::size_of::<__fsid_t>(),
+        8usize,
+        concat!("Size of: ", stringify!(__fsid_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<__fsid_t>(),
+        4usize,
+        concat!("Alignment of ", stringify!(__fsid_t))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__fsid_t>())).__val as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__fsid_t),
+            "::",
+            stringify!(__val)
+        )
+    );
+}
+pub type __clock_t = libc::c_long;
+pub type __rlim_t = libc::c_ulong;
+pub type __rlim64_t = libc::c_ulong;
+pub type __id_t = libc::c_uint;
+pub type __time_t = libc::c_long;
+pub type __useconds_t = libc::c_uint;
+pub type __suseconds_t = libc::c_long;
+pub type __daddr_t = libc::c_int;
+pub type __key_t = libc::c_int;
+pub type __clockid_t = libc::c_int;
+pub type __timer_t = *mut libc::c_void;
+pub type __blksize_t = libc::c_long;
+pub type __blkcnt_t = libc::c_long;
+pub type __blkcnt64_t = libc::c_long;
+pub type __fsblkcnt_t = libc::c_ulong;
+pub type __fsblkcnt64_t = libc::c_ulong;
+pub type __fsfilcnt_t = libc::c_ulong;
+pub type __fsfilcnt64_t = libc::c_ulong;
+pub type __fsword_t = libc::c_long;
+pub type __ssize_t = libc::c_long;
+pub type __syscall_slong_t = libc::c_long;
+pub type __syscall_ulong_t = libc::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut libc::c_char;
+pub type __intptr_t = libc::c_long;
+pub type __socklen_t = libc::c_uint;
+pub type __sig_atomic_t = libc::c_int;
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
 pub type int_fast8_t = libc::c_schar;
 pub type int_fast16_t = libc::c_long;
 pub type int_fast32_t = libc::c_long;
@@ -138,8 +246,8 @@ pub type uint_fast8_t = libc::c_uchar;
 pub type uint_fast16_t = libc::c_ulong;
 pub type uint_fast32_t = libc::c_ulong;
 pub type uint_fast64_t = libc::c_ulong;
-pub type intmax_t = libc::c_long;
-pub type uintmax_t = libc::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct crocksdb_cloud_envoptions_t {
@@ -1736,6 +1844,11 @@ extern "C" {
     pub fn crocksdb_compactionjobinfo_num_corrupt_keys(
         arg1: *const crocksdb_compactionjobinfo_t,
     ) -> u64;
+}
+extern "C" {
+    pub fn crocksdb_compactionjobinfo_base_input_level(
+        arg1: *const crocksdb_compactionjobinfo_t,
+    ) -> libc::c_int;
 }
 extern "C" {
     pub fn crocksdb_compactionjobinfo_output_level(
@@ -3517,6 +3630,17 @@ extern "C" {
     pub fn crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
         opt: *mut crocksdb_ingestexternalfileoptions_t,
         allow_blocking_flush: libc::c_uchar,
+    );
+}
+extern "C" {
+    pub fn crocksdb_ingestexternalfileoptions_get_write_global_seqno(
+        opt: *const crocksdb_ingestexternalfileoptions_t,
+    ) -> libc::c_uchar;
+}
+extern "C" {
+    pub fn crocksdb_ingestexternalfileoptions_set_write_global_seqno(
+        opt: *mut crocksdb_ingestexternalfileoptions_t,
+        write_global_seqno: libc::c_uchar,
     );
 }
 extern "C" {

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4461,6 +4461,11 @@ void crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
   opt->rep.allow_blocking_flush = allow_blocking_flush;
 }
 
+unsigned char crocksdb_ingestexternalfileoptions_get_write_global_seqno(
+    const crocksdb_ingestexternalfileoptions_t* opt) {
+  return opt->rep.write_global_seqno;
+}
+
 void crocksdb_ingestexternalfileoptions_set_write_global_seqno(
     crocksdb_ingestexternalfileoptions_t* opt,
     unsigned char write_global_seqno) {

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4461,6 +4461,12 @@ void crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
   opt->rep.allow_blocking_flush = allow_blocking_flush;
 }
 
+void crocksdb_ingestexternalfileoptions_set_write_global_seqno(
+    crocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char write_global_seqno) {
+  opt->rep.write_global_seqno = write_global_seqno;
+}
+
 void crocksdb_ingestexternalfileoptions_destroy(
     crocksdb_ingestexternalfileoptions_t* opt) {
   delete opt;

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1778,13 +1778,15 @@ extern C_ROCKSDB_LIBRARY_API void
 crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
     crocksdb_ingestexternalfileoptions_t* opt,
     unsigned char allow_blocking_flush);
+extern C_ROCKSDB_LIBRARY_API unsigned char
+crocksdb_ingestexternalfileoptions_get_write_global_seqno(
+    const crocksdb_ingestexternalfileoptions_t* opt);
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_ingestexternalfileoptions_set_write_global_seqno(
     crocksdb_ingestexternalfileoptions_t* opt,
     unsigned char write_global_seqno);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_ingestexternalfileoptions_destroy(
     crocksdb_ingestexternalfileoptions_t* opt);
-
 extern C_ROCKSDB_LIBRARY_API void crocksdb_ingest_external_file(
     crocksdb_t* db, const char* const* file_list, const size_t list_len,
     const crocksdb_ingestexternalfileoptions_t* opt, char** errptr);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1778,6 +1778,10 @@ extern C_ROCKSDB_LIBRARY_API void
 crocksdb_ingestexternalfileoptions_set_allow_blocking_flush(
     crocksdb_ingestexternalfileoptions_t* opt,
     unsigned char allow_blocking_flush);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_ingestexternalfileoptions_set_write_global_seqno(
+    crocksdb_ingestexternalfileoptions_t* opt,
+    unsigned char write_global_seqno);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_ingestexternalfileoptions_destroy(
     crocksdb_ingestexternalfileoptions_t* opt);
 

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1636,6 +1636,9 @@ extern "C" {
         opt: *mut IngestExternalFileOptions,
         allow_blocking_flush: bool,
     );
+    pub fn crocksdb_ingestexternalfileoptions_get_write_global_seqno(
+        opt: *const IngestExternalFileOptions,
+    ) -> bool;
     pub fn crocksdb_ingestexternalfileoptions_set_write_global_seqno(
         opt: *mut IngestExternalFileOptions,
         write_global_seqno: bool,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1636,6 +1636,10 @@ extern "C" {
         opt: *mut IngestExternalFileOptions,
         allow_blocking_flush: bool,
     );
+    pub fn crocksdb_ingestexternalfileoptions_set_write_global_seqno(
+        opt: *mut IngestExternalFileOptions,
+        write_global_seqno: bool,
+    );
     pub fn crocksdb_ingestexternalfileoptions_destroy(opt: *mut IngestExternalFileOptions);
 
     // KeyManagedEncryptedEnv

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -2081,6 +2081,17 @@ impl IngestExternalFileOptions {
             );
         }
     }
+    
+    /// If set to true, a global_seqno will be written to a given offset in the external SST file
+    /// for backward compatibility.
+    pub fn write_global_seqno(&mut self, whether_write: bool) {
+        unsafe {
+            crocksdb_ffi::crocksdb_ingestexternalfileoptions_set_write_global_seqno(
+                self.inner,
+                whether_write,
+            );
+        }
+    }
 }
 
 impl Drop for IngestExternalFileOptions {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -2082,9 +2082,15 @@ impl IngestExternalFileOptions {
         }
     }
     
+    pub fn get_write_global_seqno(&mut self) -> bool {
+        unsafe { 
+	    crocksdb_ffi::crocksdb_ingestexternalfileoptions_get_write_global_seqno(self.inner)
+	}
+    }
+
     /// If set to true, a global_seqno will be written to a given offset in the external SST file
     /// for backward compatibility.
-    pub fn write_global_seqno(&mut self, whether_write: bool) {
+    pub fn set_write_global_seqno(&mut self, whether_write: bool) {
         unsafe {
             crocksdb_ffi::crocksdb_ingestexternalfileoptions_set_write_global_seqno(
                 self.inner,

--- a/tests/cases/test_ingest_external_file.rs
+++ b/tests/cases/test_ingest_external_file.rs
@@ -554,3 +554,12 @@ fn test_read_invalid_sst() {
     let error_message = reader.verify_checksum().unwrap_err();
     assert!(error_message.contains("checksum mismatch"));
 }
+
+#[test]
+fn test_ingest_external_file_options() {
+    let mut ingest_opt = IngestExternalFileOptions::new();
+    ingest_opt.set_write_global_seqno(false);
+    assert_eq!(false, ingest_opt.get_write_global_seqno());
+    ingest_opt.set_write_global_seqno(true);
+    assert_eq!(true, ingest_opt.get_write_global_seqno());
+}


### PR DESCRIPTION
See the issue [here](https://github.com/tikv/tikv/issues/10430) 

This PR provides the Rust API of setting `IngestExternalFileOptions::write_global_seqno`

Signed-off-by: Yang Zhang <yang.zhang@pingcap.com>