### PR TITLE
Allow compaction filter on flush

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
-	url = https://github.com/mrcroxx/rocksdb.git
-	branch = pick/facebook-rocksdb-pr8243
+	url = https://github.com/tikv/rocksdb.git
+	branch = 6.4.tikv
 
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
-	url = https://github.com/tikv/rocksdb.git
-	branch = 6.4.tikv
+	url = https://github.com/mrcroxx/rocksdb.git
+	branch = pick/facebook-rocksdb-pr8243
 
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan

--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 links = "rocksdb"
 
 [dependencies]
-bzip2-sys = "0.1.8+1.0.8" 
+bzip2-sys = { version = "0.1.11+1.0.8", features = ["static"] }
 libc = "0.2.11"
 libtitan_sys = { path = "libtitan_sys" }
 libz-sys = { version = "1.1", features = ["static"] }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -78,7 +78,6 @@ using rocksdb::ColumnFamilyDescriptor;
 using rocksdb::ColumnFamilyHandle;
 using rocksdb::ColumnFamilyOptions;
 using rocksdb::CompactionFilter;
-using rocksdb::CompactionFilterContext;
 using rocksdb::CompactionFilterFactory;
 using rocksdb::CompactionJobInfo;
 using rocksdb::CompactionOptionsFIFO;

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -372,10 +372,6 @@ struct crocksdb_keyversions_t {
   std::vector<KeyVersion> rep;
 };
 
-struct crocksdb_tablefilecreationreason_t {
-  TableFileCreationReason rep;
-};
-
 struct crocksdb_compactionfiltercontext_t {
   CompactionFilter::Context rep;
 };
@@ -441,7 +437,7 @@ struct crocksdb_compactionfilterfactory_t : public CompactionFilterFactory {
   crocksdb_compactionfilter_t* (*create_compaction_filter_)(
       void*, crocksdb_compactionfiltercontext_t* context);
   bool (*should_filter_table_file_creation_)(
-      void*, crocksdb_tablefilecreationreason_t* reason);
+      void*, crocksdb_tablefilecreationreason_t reason);
   const char* (*name_)(void*);
 
   virtual ~crocksdb_compactionfilterfactory_t() { (*destructor_)(state_); }
@@ -456,9 +452,9 @@ struct crocksdb_compactionfilterfactory_t : public CompactionFilterFactory {
 
   virtual bool ShouldFilterTableFileCreation(
       TableFileCreationReason reason) const override {
-    crocksdb_tablefilecreationreason_t creason;
-    creason.rep = reason;
-    return (*should_filter_table_file_creation_)(state_, &creason);
+    crocksdb_tablefilecreationreason_t creason =
+        static_cast<crocksdb_tablefilecreationreason_t>(reason);
+    return (*should_filter_table_file_creation_)(state_, creason);
   }
 
   virtual const char* Name() const override { return (*name_)(state_); }
@@ -3450,7 +3446,7 @@ crocksdb_compactionfilterfactory_t* crocksdb_compactionfilterfactory_create(
     crocksdb_compactionfilter_t* (*create_compaction_filter)(
         void*, crocksdb_compactionfiltercontext_t* context),
     bool (*should_filter_table_file_creation)(
-        void*, crocksdb_tablefilecreationreason_t* reason),
+        void*, crocksdb_tablefilecreationreason_t reason),
     const char* (*name)(void*)) {
   crocksdb_compactionfilterfactory_t* result =
       new crocksdb_compactionfilterfactory_t;

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -436,8 +436,7 @@ struct crocksdb_compactionfilterfactory_t : public CompactionFilterFactory {
   void (*destructor_)(void*);
   crocksdb_compactionfilter_t* (*create_compaction_filter_)(
       void*, crocksdb_compactionfiltercontext_t* context);
-  bool (*should_filter_table_file_creation_)(
-      void*, crocksdb_tablefilecreationreason_t reason);
+  bool (*should_filter_table_file_creation_)(void*, int reason);
   const char* (*name_)(void*);
 
   virtual ~crocksdb_compactionfilterfactory_t() { (*destructor_)(state_); }
@@ -452,8 +451,7 @@ struct crocksdb_compactionfilterfactory_t : public CompactionFilterFactory {
 
   virtual bool ShouldFilterTableFileCreation(
       TableFileCreationReason reason) const override {
-    crocksdb_tablefilecreationreason_t creason =
-        static_cast<crocksdb_tablefilecreationreason_t>(reason);
+    int creason = static_cast<int>(reason);
     return (*should_filter_table_file_creation_)(state_, creason);
   }
 
@@ -3445,8 +3443,7 @@ crocksdb_compactionfilterfactory_t* crocksdb_compactionfilterfactory_create(
     void* state, void (*destructor)(void*),
     crocksdb_compactionfilter_t* (*create_compaction_filter)(
         void*, crocksdb_compactionfiltercontext_t* context),
-    bool (*should_filter_table_file_creation)(
-        void*, crocksdb_tablefilecreationreason_t reason),
+    bool (*should_filter_table_file_creation)(void*, int reason),
     const char* (*name)(void*)) {
   crocksdb_compactionfilterfactory_t* result =
       new crocksdb_compactionfilterfactory_t;

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -80,12 +80,12 @@ typedef struct crocksdb_lru_cache_options_t crocksdb_lru_cache_options_t;
 typedef struct crocksdb_cache_t crocksdb_cache_t;
 typedef struct crocksdb_memory_allocator_t crocksdb_memory_allocator_t;
 typedef struct crocksdb_compactionfilter_t crocksdb_compactionfilter_t;
-typedef enum crocksdb_tablefilecreationreason_t {
-  Flush,
-  Compaction,
-  Recovery,
-  Misc,
-} crocksdb_tablefilecreationreason_t;
+enum {
+  crocksdb_table_file_creation_reason_flush = 0,
+  crocksdb_table_file_creation_reason_compaction = 1,
+  crocksdb_table_file_creation_reason_recovery = 2,
+  crocksdb_table_file_creation_reason_misc = 3,
+};
 typedef struct crocksdb_compactionfiltercontext_t
     crocksdb_compactionfiltercontext_t;
 typedef struct crocksdb_compactionfilterfactory_t
@@ -1392,8 +1392,7 @@ crocksdb_compactionfilterfactory_create(
     void* state, void (*destructor)(void*),
     crocksdb_compactionfilter_t* (*create_compaction_filter)(
         void*, crocksdb_compactionfiltercontext_t* context),
-    bool (*should_filter_table_file_creation)(
-        void*, crocksdb_tablefilecreationreason_t reasion),
+    bool (*should_filter_table_file_creation)(void*, int reasion),
     const char* (*name)(void*));
 extern C_ROCKSDB_LIBRARY_API void crocksdb_compactionfilterfactory_destroy(
     crocksdb_compactionfilterfactory_t*);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -80,6 +80,8 @@ typedef struct crocksdb_lru_cache_options_t crocksdb_lru_cache_options_t;
 typedef struct crocksdb_cache_t crocksdb_cache_t;
 typedef struct crocksdb_memory_allocator_t crocksdb_memory_allocator_t;
 typedef struct crocksdb_compactionfilter_t crocksdb_compactionfilter_t;
+typedef struct crocksdb_tablefilecreationreason_t
+    crocksdb_tablefilecreationreason_t;
 typedef struct crocksdb_compactionfiltercontext_t
     crocksdb_compactionfiltercontext_t;
 typedef struct crocksdb_compactionfilterfactory_t
@@ -1386,6 +1388,8 @@ crocksdb_compactionfilterfactory_create(
     void* state, void (*destructor)(void*),
     crocksdb_compactionfilter_t* (*create_compaction_filter)(
         void*, crocksdb_compactionfiltercontext_t* context),
+    bool (*should_filter_table_file_creation)(
+        void*, crocksdb_tablefilecreationreason_t* reasion),
     const char* (*name)(void*));
 extern C_ROCKSDB_LIBRARY_API void crocksdb_compactionfilterfactory_destroy(
     crocksdb_compactionfilterfactory_t*);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -80,8 +80,12 @@ typedef struct crocksdb_lru_cache_options_t crocksdb_lru_cache_options_t;
 typedef struct crocksdb_cache_t crocksdb_cache_t;
 typedef struct crocksdb_memory_allocator_t crocksdb_memory_allocator_t;
 typedef struct crocksdb_compactionfilter_t crocksdb_compactionfilter_t;
-typedef struct crocksdb_tablefilecreationreason_t
-    crocksdb_tablefilecreationreason_t;
+typedef enum crocksdb_tablefilecreationreason_t {
+  Flush,
+  Compaction,
+  Recovery,
+  Misc,
+} crocksdb_tablefilecreationreason_t;
 typedef struct crocksdb_compactionfiltercontext_t
     crocksdb_compactionfiltercontext_t;
 typedef struct crocksdb_compactionfilterfactory_t
@@ -1389,7 +1393,7 @@ crocksdb_compactionfilterfactory_create(
     crocksdb_compactionfilter_t* (*create_compaction_filter)(
         void*, crocksdb_compactionfiltercontext_t* context),
     bool (*should_filter_table_file_creation)(
-        void*, crocksdb_tablefilecreationreason_t* reasion),
+        void*, crocksdb_tablefilecreationreason_t reasion),
     const char* (*name)(void*));
 extern C_ROCKSDB_LIBRARY_API void crocksdb_compactionfilterfactory_destroy(
     crocksdb_compactionfilterfactory_t*);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -83,6 +83,16 @@ pub struct DBCompactionFilter(c_void);
 pub struct DBCompactionFilterFactory(c_void);
 #[repr(C)]
 pub struct DBCompactionFilterContext(c_void);
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub enum DBTableFileCreationReason {
+    Flush = 0,
+    Compaction = 1,
+    Recovery = 2,
+    Misc = 3,
+}
+
 #[repr(C)]
 pub struct EnvOptions(c_void);
 #[repr(C)]
@@ -1578,6 +1588,10 @@ extern "C" {
             *mut c_void,
             *const DBCompactionFilterContext,
         ) -> *mut DBCompactionFilter,
+        should_filter_table_file_creation: extern "C" fn(
+            *const c_void,
+            *const DBTableFileCreationReason,
+        ) -> bool,
         name: extern "C" fn(*mut c_void) -> *const c_char,
     ) -> *mut DBCompactionFilterFactory;
     pub fn crocksdb_compactionfilterfactory_destroy(factory: *mut DBCompactionFilterFactory);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -84,15 +84,6 @@ pub struct DBCompactionFilterFactory(c_void);
 #[repr(C)]
 pub struct DBCompactionFilterContext(c_void);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(C)]
-pub enum DBTableFileCreationReason {
-    Flush = 0,
-    Compaction = 1,
-    Recovery = 2,
-    Misc = 3,
-}
-
 #[repr(C)]
 pub struct EnvOptions(c_void);
 #[repr(C)]
@@ -473,6 +464,15 @@ pub enum CompactionFilterDecision {
     Remove = 1,
     ChangeValue = 2,
     RemoveAndSkipUntil = 3,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub enum DBTableFileCreationReason {
+    Flush = 0,
+    Compaction = 1,
+    Recovery = 2,
+    Misc = 3,
 }
 
 /// # Safety

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1590,7 +1590,7 @@ extern "C" {
         ) -> *mut DBCompactionFilter,
         should_filter_table_file_creation: extern "C" fn(
             *const c_void,
-            *const DBTableFileCreationReason,
+            DBTableFileCreationReason,
         ) -> bool,
         name: extern "C" fn(*mut c_void) -> *const c_char,
     ) -> *mut DBCompactionFilterFactory;

--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -5,7 +5,9 @@ use crate::table_properties::TableProperties;
 use crocksdb_ffi::CompactionFilterDecision as RawCompactionFilterDecision;
 pub use crocksdb_ffi::CompactionFilterValueType;
 pub use crocksdb_ffi::DBCompactionFilter;
-use crocksdb_ffi::{self, DBCompactionFilterContext, DBCompactionFilterFactory};
+use crocksdb_ffi::{
+    self, DBCompactionFilterContext, DBCompactionFilterFactory, DBTableFileCreationReason,
+};
 use libc::{c_char, c_int, c_void, malloc, memcpy, size_t};
 
 /// Decision used in `CompactionFilter::filter`.
@@ -204,6 +206,13 @@ pub trait CompactionFilterFactory {
         &self,
         context: &CompactionFilterContext,
     ) -> *mut DBCompactionFilter;
+
+    /// Returns whether a thread creating table files for the specified `reason`
+    /// should have invoke `create_compaction_filter` and pass KVs through the returned
+    /// filter.
+    fn should_filter_table_file_creation(&self, reason: &DBTableFileCreationReason) -> bool {
+        matches!(reason, DBTableFileCreationReason::Flush)
+    }
 }
 
 #[repr(C)]
@@ -216,6 +225,7 @@ mod factory {
     use super::{CompactionFilterContext, CompactionFilterFactoryProxy};
     use crocksdb_ffi::{DBCompactionFilter, DBCompactionFilterContext};
     use libc::{c_char, c_void};
+    use librocksdb_sys::DBTableFileCreationReason;
 
     pub(super) extern "C" fn name(factory: *mut c_void) -> *const c_char {
         unsafe {
@@ -238,6 +248,17 @@ mod factory {
             let factory = &mut *(factory as *mut CompactionFilterFactoryProxy);
             let context: &CompactionFilterContext = &*(context as *const CompactionFilterContext);
             factory.factory.create_compaction_filter(context)
+        }
+    }
+
+    pub(super) extern "C" fn should_filter_table_file_creation(
+        factory: *const c_void,
+        reason: *const DBTableFileCreationReason,
+    ) -> bool {
+        unsafe {
+            let factory = &*(factory as *const CompactionFilterFactoryProxy);
+            let reason: &DBTableFileCreationReason = &*(reason as *const DBTableFileCreationReason);
+            factory.factory.should_filter_table_file_creation(reason)
         }
     }
 }
@@ -267,6 +288,7 @@ pub unsafe fn new_compaction_filter_factory(
         proxy as *mut c_void,
         self::factory::destructor,
         self::factory::create_compaction_filter,
+        self::factory::should_filter_table_file_creation,
         self::factory::name,
     );
 
@@ -279,10 +301,13 @@ mod tests {
     use std::sync::mpsc::{self, SyncSender};
     use std::time::Duration;
 
+    use librocksdb_sys::DBTableFileCreationReason;
+
     use super::{
-        CompactionFilter, CompactionFilterContext, CompactionFilterFactory, DBCompactionFilter,
+        new_compaction_filter_raw, CompactionFilter, CompactionFilterContext,
+        CompactionFilterFactory, DBCompactionFilter,
     };
-    use crate::{ColumnFamilyOptions, DBOptions, DB};
+    use crate::{ColumnFamilyOptions, DBOptions, Writable, DB};
 
     struct Factory(SyncSender<()>);
     impl Drop for Factory {
@@ -305,6 +330,29 @@ mod tests {
     impl CompactionFilter for Filter {
         fn filter(&mut self, _: usize, _: &[u8], _: &[u8], _: &mut Vec<u8>, _: &mut bool) -> bool {
             false
+        }
+    }
+
+    struct FlushFactory {}
+    struct FlushFilter {}
+    impl CompactionFilter for FlushFilter {
+        fn filter(&mut self, _: usize, _: &[u8], _: &[u8], _: &mut Vec<u8>, _: &mut bool) -> bool {
+            true
+        }
+    }
+
+    impl CompactionFilterFactory for FlushFactory {
+        fn should_filter_table_file_creation(&self, reason: &DBTableFileCreationReason) -> bool {
+            matches!(reason, DBTableFileCreationReason::Flush)
+        }
+
+        fn create_compaction_filter(
+            &self,
+            _context: &CompactionFilterContext,
+        ) -> *mut DBCompactionFilter {
+            let filter = Box::new(FlushFilter {});
+            let name = CString::new("flush_compaction_filter").unwrap();
+            unsafe { new_compaction_filter_raw(name, filter) }
         }
     }
 
@@ -374,5 +422,43 @@ mod tests {
         let db = DB::open_cf(db_opts, path, cfds);
         drop(db);
         assert!(rx.recv_timeout(Duration::from_secs(1)).is_ok());
+    }
+
+    #[test]
+    fn test_flush_filter() {
+        // cf with filter
+        let name = CString::new("test_flush_filter_factory").unwrap();
+        let factory = Box::new(FlushFactory {}) as Box<dyn CompactionFilterFactory>;
+        let mut cf_opts_wf = ColumnFamilyOptions::default();
+        cf_opts_wf
+            .set_compaction_filter_factory(name, factory)
+            .unwrap();
+        cf_opts_wf.set_disable_auto_compactions(true);
+
+        // cf without filter
+        let mut cf_opts_of = ColumnFamilyOptions::default();
+        cf_opts_of.set_disable_auto_compactions(true);
+
+        // db
+        let mut opts = DBOptions::new();
+        opts.create_if_missing(true);
+        let path = tempfile::Builder::new()
+            .prefix("test_factory_context_keys")
+            .tempdir()
+            .unwrap();
+        let mut db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
+        db.create_cf(("wf", cf_opts_wf)).unwrap();
+        db.create_cf(("of", cf_opts_of)).unwrap();
+        let cfh_wf = db.cf_handle("wf").unwrap();
+        let cfh_of = db.cf_handle("of").unwrap();
+
+        // put data
+        db.put_cf(cfh_wf, b"k", b"v").unwrap();
+        db.put_cf(cfh_of, b"k", b"v").unwrap();
+        db.flush_cf(cfh_wf, true).unwrap();
+        db.flush_cf(cfh_of, true).unwrap();
+
+        assert!(db.get_cf(cfh_wf, b"k").unwrap().is_none());
+        assert!(db.get_cf(cfh_of, b"k").unwrap().is_some());
     }
 }

--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -458,6 +458,8 @@ mod tests {
         db.flush_cf(cfh_wf, true).unwrap();
         db.flush_cf(cfh_of, true).unwrap();
 
+
+        // assert
         assert!(db.get_cf(cfh_wf, b"k").unwrap().is_none());
         assert!(db.get_cf(cfh_of, b"k").unwrap().is_some());
     }

--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -210,7 +210,7 @@ pub trait CompactionFilterFactory {
     /// Returns whether a thread creating table files for the specified `reason`
     /// should have invoke `create_compaction_filter` and pass KVs through the returned
     /// filter.
-    fn should_filter_table_file_creation(&self, reason: &DBTableFileCreationReason) -> bool {
+    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
         matches!(reason, DBTableFileCreationReason::Flush)
     }
 }
@@ -253,11 +253,11 @@ mod factory {
 
     pub(super) extern "C" fn should_filter_table_file_creation(
         factory: *const c_void,
-        reason: *const DBTableFileCreationReason,
+        reason: DBTableFileCreationReason,
     ) -> bool {
         unsafe {
             let factory = &*(factory as *const CompactionFilterFactoryProxy);
-            let reason: &DBTableFileCreationReason = &*(reason as *const DBTableFileCreationReason);
+            let reason: DBTableFileCreationReason = reason as DBTableFileCreationReason;
             factory.factory.should_filter_table_file_creation(reason)
         }
     }
@@ -342,7 +342,7 @@ mod tests {
     }
 
     impl CompactionFilterFactory for FlushFactory {
-        fn should_filter_table_file_creation(&self, reason: &DBTableFileCreationReason) -> bool {
+        fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
             matches!(reason, DBTableFileCreationReason::Flush)
         }
 

--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -458,7 +458,6 @@ mod tests {
         db.flush_cf(cfh_wf, true).unwrap();
         db.flush_cf(cfh_of, true).unwrap();
 
-
         // assert
         assert!(db.get_cf(cfh_wf, b"k").unwrap().is_none());
         assert!(db.get_cf(cfh_of, b"k").unwrap().is_some());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@ pub use librocksdb_sys::{
     DBBackgroundErrorReason, DBBottommostLevelCompaction, DBCompactionStyle, DBCompressionType,
     DBEntryType, DBInfoLogLevel, DBRateLimiterMode, DBRecoveryMode,
     DBSstPartitionerResult as SstPartitionerResult, DBStatisticsHistogramType,
-    DBStatisticsTickerType, DBStatusPtr, DBTitanDBBlobRunMode, DBValueType, IndexType,
-    WriteStallCondition,
+    DBStatisticsTickerType, DBStatusPtr, DBTableFileCreationReason, DBTitanDBBlobRunMode,
+    DBValueType, IndexType, WriteStallCondition,
 };
 pub use logger::Logger;
 pub use merge_operator::MergeOperands;

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -2081,11 +2081,11 @@ impl IngestExternalFileOptions {
             );
         }
     }
-    
+
     pub fn get_write_global_seqno(&mut self) -> bool {
-        unsafe { 
-	    crocksdb_ffi::crocksdb_ingestexternalfileoptions_get_write_global_seqno(self.inner)
-	}
+        unsafe {
+            crocksdb_ffi::crocksdb_ingestexternalfileoptions_get_write_global_seqno(self.inner)
+        }
     }
 
     /// If set to true, a global_seqno will be written to a given offset in the external SST file

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -2082,7 +2082,7 @@ impl IngestExternalFileOptions {
         }
     }
 
-    pub fn get_write_global_seqno(&mut self) -> bool {
+    pub fn get_write_global_seqno(&self) -> bool {
         unsafe {
             crocksdb_ffi::crocksdb_ingestexternalfileoptions_get_write_global_seqno(self.inner)
         }


### PR DESCRIPTION
Allow compaction filter on flush.

Ref: [tikv/rocksdb#pr243](https://github.com/tikv/rocksdb/pull/243)

TODO:

- [x] Redirect submodule `rocksdb` back to `tikv/rocksdb` branch `6.4.tikv` after pull#243 is merged.