### PR TITLE
simplify impl of read table properties

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4368,11 +4368,10 @@ crocksdb_iterator_t* crocksdb_sstfilereader_new_iterator(
   return it;
 }
 
-void crocksdb_sstfilereader_read_table_properties(
-    const crocksdb_sstfilereader_t* reader, void* ctx,
-    void (*cb)(void*, const crocksdb_table_properties_t*)) {
+const crocksdb_table_properties_t* crocksdb_sstfilereader_read_table_properties(
+    const crocksdb_sstfilereader_t* reader) {
   auto props = reader->rep->GetTableProperties();
-  cb(ctx, reinterpret_cast<const crocksdb_table_properties_t*>(props.get()));
+  return reinterpret_cast<const crocksdb_table_properties_t*>(props.get());
 }
 
 void crocksdb_sstfilereader_verify_checksum(crocksdb_sstfilereader_t* reader,

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1724,9 +1724,9 @@ extern C_ROCKSDB_LIBRARY_API crocksdb_iterator_t*
 crocksdb_sstfilereader_new_iterator(crocksdb_sstfilereader_t* reader,
                                     const crocksdb_readoptions_t* options);
 
-extern C_ROCKSDB_LIBRARY_API void crocksdb_sstfilereader_read_table_properties(
-    const crocksdb_sstfilereader_t* reader, void* ctx,
-    void (*cb)(void*, const crocksdb_table_properties_t*));
+extern C_ROCKSDB_LIBRARY_API const crocksdb_table_properties_t*
+crocksdb_sstfilereader_read_table_properties(
+    const crocksdb_sstfilereader_t* reader);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_sstfilereader_verify_checksum(
     crocksdb_sstfilereader_t* reader, char** errptr);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1802,9 +1802,7 @@ extern "C" {
 
     pub fn crocksdb_sstfilereader_read_table_properties(
         reader: *const SstFileReader,
-        ctx: *mut c_void,
-        callback: extern "C" fn(*mut c_void, *const DBTableProperties),
-    );
+    ) -> *const DBTableProperties;
 
     pub fn crocksdb_sstfilereader_verify_checksum(
         reader: *mut SstFileReader,


### PR DESCRIPTION
`Rudra` complains about the potential double-free issue https://paper.seebug.org/1728/#05-panic-safety-double-free-rustsec-2021-0011, so simplify it to avoid using `mem::forget`

```rust
// Warning (UnsafeDataflow:/ReadFlow): Potential unsafe dataflow issue in 
// `rocksdb::SstFileReader::read_table_properties::callback`
// -> src/rocksdb.rs:2330:9: 2338:10
extern "C" fn callback<F: FnOnce(&TableProperties)>(
            ctx: *mut c_void,
            ptr: *const crocksdb_ffi::DBTableProperties,
        ) {
            unsafe {
                let caller = ptr::read(ctx as *mut F);
                caller(TableProperties::from_ptr(ptr));
            }
        }

```