### PR TITLE
Add `reset` for status to allow users to clear internal error

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2094,6 +2094,11 @@ unsigned char crocksdb_flushjobinfo_triggered_writes_stop(
   return info->rep.triggered_writes_stop;
 }
 
+void crocksdb_reset_status(crocksdb_status_ptr_t* status_ptr) {
+  auto ptr = status_ptr->rep;
+  *ptr = Status::OK();
+}
+
 /* CompactionJobInfo */
 
 void crocksdb_compactionjobinfo_status(const crocksdb_compactionjobinfo_t* info,

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -807,6 +807,9 @@ crocksdb_flushjobinfo_triggered_writes_slowdown(const crocksdb_flushjobinfo_t*);
 extern C_ROCKSDB_LIBRARY_API unsigned char
 crocksdb_flushjobinfo_triggered_writes_stop(const crocksdb_flushjobinfo_t*);
 
+extern C_ROCKSDB_LIBRARY_API void crocksdb_reset_status(
+    crocksdb_status_ptr_t* status_ptr);
+
 /* Compaction job info */
 extern C_ROCKSDB_LIBRARY_API void crocksdb_compactionjobinfo_status(
     const crocksdb_compactionjobinfo_t* info, char** errptr);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -2155,7 +2155,7 @@ extern "C" {
     ) -> *const DBTableProperties;
     pub fn crocksdb_flushjobinfo_triggered_writes_slowdown(info: *const DBFlushJobInfo) -> bool;
     pub fn crocksdb_flushjobinfo_triggered_writes_stop(info: *const DBFlushJobInfo) -> bool;
-
+    pub fn crocksdb_reset_status(ptr: *mut DBStatusPtr);
     pub fn crocksdb_compactionjobinfo_status(
         info: *const DBCompactionJobInfo,
         errptr: *mut *mut c_char,

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -59,13 +59,13 @@ impl FlushJobInfo {
     }
 }
 
-pub struct Status {
+pub struct MutableStatus {
     result: Result<(), String>,
     ptr: *mut DBStatusPtr,
 }
 
-impl Status {
-    pub fn reset_status(&self) {
+impl MutableStatus {
+    pub fn reset(&self) {
         unsafe { crocksdb_ffi::crocksdb_reset_status(self.ptr) }
     }
 
@@ -240,7 +240,7 @@ pub trait EventListener: Send + Sync {
     fn on_subcompaction_begin(&self, _: &SubcompactionJobInfo) {}
     fn on_subcompaction_completed(&self, _: &SubcompactionJobInfo) {}
     fn on_external_file_ingested(&self, _: &IngestionInfo) {}
-    fn on_background_error(&self, _: DBBackgroundErrorReason, _: Status) {}
+    fn on_background_error(&self, _: DBBackgroundErrorReason, _: MutableStatus) {}
     fn on_stall_conditions_changed(&self, _: &WriteStallInfo) {}
 }
 
@@ -327,7 +327,7 @@ extern "C" fn on_background_error<E: EventListener>(
             }(),
         )
     };
-    let status = Status {
+    let status = MutableStatus {
         result: result,
         ptr: status_ptr,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub use compaction_filter::{
 #[cfg(feature = "encryption")]
 pub use encryption::{DBEncryptionMethod, EncryptionKeyManager, FileEncryptionInfo};
 pub use event_listener::{
-    CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo, SubcompactionJobInfo,
+    CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo, StatusPtr, SubcompactionJobInfo,
     WriteStallInfo,
 };
 pub use file_system::FileSystemInspector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,8 @@ pub use compaction_filter::{
 #[cfg(feature = "encryption")]
 pub use encryption::{DBEncryptionMethod, EncryptionKeyManager, FileEncryptionInfo};
 pub use event_listener::{
-    CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo, Status, SubcompactionJobInfo,
-    WriteStallInfo,
+    CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo, MutableStatus,
+    SubcompactionJobInfo, WriteStallInfo,
 };
 pub use file_system::FileSystemInspector;
 pub use librocksdb_sys::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub use compaction_filter::{
 #[cfg(feature = "encryption")]
 pub use encryption::{DBEncryptionMethod, EncryptionKeyManager, FileEncryptionInfo};
 pub use event_listener::{
-    CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo, StatusPtr, SubcompactionJobInfo,
+    CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo, Status, SubcompactionJobInfo,
     WriteStallInfo,
 };
 pub use file_system::FileSystemInspector;

--- a/tests/cases/test_event_listener.rs
+++ b/tests/cases/test_event_listener.rs
@@ -133,7 +133,7 @@ struct BackgroundErrorCounter {
 }
 
 impl EventListener for BackgroundErrorCounter {
-    fn on_background_error(&self, _: DBBackgroundErrorReason, _: Status) {
+    fn on_background_error(&self, _: DBBackgroundErrorReason, _: MutableStatus) {
         self.background_error.fetch_add(1, Ordering::SeqCst);
     }
 }
@@ -290,8 +290,8 @@ fn test_event_listener_background_error() {
 struct BackgroundErrorCleaner(Arc<AtomicUsize>);
 
 impl EventListener for BackgroundErrorCleaner {
-    fn on_background_error(&self, _: DBBackgroundErrorReason, s: Status) {
-        s.reset_status();
+    fn on_background_error(&self, _: DBBackgroundErrorReason, s: MutableStatus) {
+        s.reset();
         self.0.fetch_add(1, Ordering::SeqCst);
     }
 }

--- a/tests/cases/test_event_listener.rs
+++ b/tests/cases/test_event_listener.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io::Write;
+use std::path::Path;
 use std::sync::atomic::*;
 use std::sync::Arc;
 
@@ -131,7 +133,7 @@ struct BackgroundErrorCounter {
 }
 
 impl EventListener for BackgroundErrorCounter {
-    fn on_background_error(&self, _: DBBackgroundErrorReason, _: Result<(), String>) {
+    fn on_background_error(&self, _: DBBackgroundErrorReason, _: Status) {
         self.background_error.fetch_add(1, Ordering::SeqCst);
     }
 }
@@ -282,4 +284,60 @@ fn test_event_listener_background_error() {
         db.flush(false).unwrap();
     }
     assert_eq!(counter.background_error.load(Ordering::SeqCst), 0);
+}
+
+#[derive(Default, Clone)]
+struct BackgroundErrorCleaner(Arc<AtomicUsize>);
+
+impl EventListener for BackgroundErrorCleaner {
+    fn on_background_error(&self, _: DBBackgroundErrorReason, s: Status) {
+        s.reset_status();
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn test_event_listener_status_reset() {
+    let path = tempdir_with_prefix("_test_event_listener_status_reset");
+    let path_str = path.path().to_str().unwrap();
+
+    let mut opts = DBOptions::new();
+    let cleaner = BackgroundErrorCleaner::default();
+    let counter = cleaner.0.clone();
+    opts.add_event_listener(cleaner.clone());
+    opts.create_if_missing(true);
+    let db = DB::open(opts, path_str).unwrap();
+
+    for i in 1..5 {
+        db.put(format!("{:04}", i).as_bytes(), b"value").unwrap();
+    }
+    db.flush(true).unwrap();
+
+    disturb_sst_file(&db, path.path());
+
+    for i in 1..5 {
+        db.put(format!("{:04}", i).as_bytes(), b"value").unwrap();
+    }
+    compact_files_to_bottom(&db);
+    db.flush(true).unwrap();
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+fn disturb_sst_file(db: &DB, path: &Path) {
+    let files = db.get_live_files();
+    let mut file_name = files.get_name(0);
+    file_name.remove(0);
+
+    let sst_path = path.to_path_buf().join(file_name);
+
+    let mut file = std::fs::File::create(sst_path).unwrap();
+    file.write(b"surprise").unwrap();
+    file.sync_all().unwrap();
+}
+
+fn compact_files_to_bottom(db: &DB) {
+    let mut opt = CompactionOptions::new();
+    opt.set_max_subcompactions(1);
+    // output_level should be from 0 to 6.
+    db.compact_range(None, None);
 }


### PR DESCRIPTION
This api allows users to reset status error returned from rocksdb internal error.

Signed-off-by: Xintao <hunterlxt@live.com>