### PR TITLE
update zstd-sys dep

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.11"
 libtitan_sys = { path = "libtitan_sys" }
 libz-sys = { version = "1.1", features = ["static"] }
 openssl-sys = { version = "0.9.54", optional = true, features = ["vendored"] }
-zstd-sys = "1.4.19+zstd.1.4.8"
+zstd-sys = "2.0.1+zstd.1.5.2"
 lz4-sys = "1.9"
 
 [dev-dependencies]

--- a/librocksdb_sys/libtitan_sys/Cargo.toml
+++ b/librocksdb_sys/libtitan_sys/Cargo.toml
@@ -8,7 +8,7 @@ links = "titan"
 bzip2-sys = "0.1.8+1.0.8"
 libc = "0.2.11"
 libz-sys = { version = "1.1", features = ["static"] }
-zstd-sys = "1.4.15+zstd.1.4.4"
+zstd-sys = "2.0.1+zstd.1.5.2"
 lz4-sys = "1.9"
 
 [features]


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

bump `zstd-sys` to `2.0.1+zstd.1.5.2` https://docs.rs/zstd-sys/2.0.1+zstd.1.5.2/zstd_sys/index.html

zstd's release note: https://github.com/facebook/zstd/releases

run `cargo test` with one failing case
```
---- cases::test_rocksdb_options::test_direct_read_write stdout ----
thread 'cases::test_rocksdb_options::test_direct_read_write' panicked at 'called `Result::unwrap()` on an `Err` value: "Invalid argument: Direct I/O is not supported by the specified DB."', tests/cases/test_rocksdb_options.rs:569:51
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This case also failed on master in my env(