### PR TITLE
delete set_sample_ratio

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -6554,6 +6554,11 @@ void ctitandb_options_set_discardable_ratio(ctitandb_options_t* options,
   options->rep.blob_file_discardable_ratio = ratio;
 }
 
+void ctitandb_options_set_sample_ratio(ctitandb_options_t* options,
+                                       double ratio) {
+  options->rep.sample_file_size_ratio = ratio;
+}
+
 void ctitandb_options_set_blob_run_mode(ctitandb_options_t* options, int mode) {
   options->rep.blob_run_mode = static_cast<TitanBlobRunMode>(mode);
 }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -6554,11 +6554,6 @@ void ctitandb_options_set_discardable_ratio(ctitandb_options_t* options,
   options->rep.blob_file_discardable_ratio = ratio;
 }
 
-void ctitandb_options_set_sample_ratio(ctitandb_options_t* options,
-                                       double ratio) {
-  options->rep.sample_file_size_ratio = ratio;
-}
-
 void ctitandb_options_set_blob_run_mode(ctitandb_options_t* options, int mode) {
   options->rep.blob_run_mode = static_cast<TitanBlobRunMode>(mode);
 }

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -2615,9 +2615,6 @@ extern C_ROCKSDB_LIBRARY_API void ctitandb_options_set_discardable_ratio(
     ctitandb_options_t* options, double ratio);
 
 extern void C_ROCKSDB_LIBRARY_API
-ctitandb_options_set_sample_ratio(ctitandb_options_t* options, double ratio);
-
-extern void C_ROCKSDB_LIBRARY_API
 ctitandb_options_set_blob_run_mode(ctitandb_options_t* options, int mode);
 
 /* TitanReadOptions */

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -2707,7 +2707,6 @@ extern "C" {
     pub fn ctitandb_options_get_blob_cache_capacity(options: *const DBTitanDBOptions) -> usize;
 
     pub fn ctitandb_options_set_discardable_ratio(opts: *mut DBTitanDBOptions, ratio: f64);
-    pub fn ctitandb_options_set_sample_ratio(opts: *mut DBTitanDBOptions, ratio: f64);
     pub fn ctitandb_options_set_merge_small_file_threshold(opts: *mut DBTitanDBOptions, size: u64);
     pub fn ctitandb_options_set_blob_run_mode(opts: *mut DBTitanDBOptions, t: DBTitanDBBlobRunMode);
 

--- a/src/titan.rs
+++ b/src/titan.rs
@@ -152,12 +152,6 @@ impl TitanDBOptions {
         }
     }
 
-    pub fn set_sample_ratio(&mut self, ratio: f64) {
-        unsafe {
-            crocksdb_ffi::ctitandb_options_set_sample_ratio(self.inner, ratio);
-        }
-    }
-
     pub fn set_merge_small_file_threshold(&mut self, size: u64) {
         unsafe {
             crocksdb_ffi::ctitandb_options_set_merge_small_file_threshold(self.inner, size);


### PR DESCRIPTION
set_sample_ratio is not deleted in #699 (https://github.com/tikv/rust-rocksdb/pull/699/files#r903662454)

Signed-off-by: tabokie <xy.tao@outlook.com>