### PR TITLE
*: support check if a db is lock

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4088,9 +4088,9 @@ struct CTRBlockCipher : public BlockCipher {
 
   const char* Name() const override { return "CTRBlockCipher"; }
 
-  virtual size_t BlockSize() { return block_size_; }
+  size_t BlockSize() override { return block_size_; }
 
-  virtual Status Encrypt(char* data) {
+  Status Encrypt(char* data) override {
     const char* ciper_ptr = cipertext_.c_str();
     for (size_t i = 0; i < block_size_; i++) {
       data[i] = data[i] ^ ciper_ptr[i];
@@ -4099,7 +4099,7 @@ struct CTRBlockCipher : public BlockCipher {
     return Status::OK();
   }
 
-  virtual Status Decrypt(char* data) {
+  Status Decrypt(char* data) override {
     Encrypt(data);
     return Status::OK();
   }
@@ -4144,6 +4144,22 @@ void crocksdb_env_file_exists(crocksdb_env_t* env, const char* path,
 void crocksdb_env_delete_file(crocksdb_env_t* env, const char* path,
                               char** errptr) {
   SaveError(errptr, env->rep->DeleteFile(path));
+}
+
+unsigned char crocksdb_env_is_db_locked(crocksdb_env_t* env, const char* path, char** errptr) {
+  FileLock* lock;
+  std::string file = rocksdb::LockFileName(path);
+  Status s = env->rep->LockFile(file, &lock);
+  if (s.ok()) {
+    env->rep->UnlockFile(lock);
+    return false;
+  } else {
+    const char* state = s.getState();
+    if (state == nullptr || (std::strstr(state, "lock hold") == nullptr && std::strstr(state, "While lock file") == nullptr)) {
+      SaveError(errptr, s);
+    }
+    return true;
+  }
 }
 
 void crocksdb_env_destroy(crocksdb_env_t* env) {

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4146,7 +4146,8 @@ void crocksdb_env_delete_file(crocksdb_env_t* env, const char* path,
   SaveError(errptr, env->rep->DeleteFile(path));
 }
 
-unsigned char crocksdb_env_is_db_locked(crocksdb_env_t* env, const char* path, char** errptr) {
+unsigned char crocksdb_env_is_db_locked(crocksdb_env_t* env, const char* path,
+                                        char** errptr) {
   FileLock* lock;
   std::string file = rocksdb::LockFileName(path);
   Status s = env->rep->LockFile(file, &lock);
@@ -4155,7 +4156,9 @@ unsigned char crocksdb_env_is_db_locked(crocksdb_env_t* env, const char* path, c
     return false;
   } else {
     const char* state = s.getState();
-    if (state == nullptr || (std::strstr(state, "lock hold") == nullptr && std::strstr(state, "While lock file") == nullptr)) {
+    if (state == nullptr ||
+        (std::strstr(state, "lock hold") == nullptr &&
+         std::strstr(state, "While lock file") == nullptr)) {
       SaveError(errptr, s);
     }
     return true;

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1686,7 +1686,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_env_file_exists(crocksdb_env_t* env,
 extern C_ROCKSDB_LIBRARY_API void crocksdb_env_delete_file(crocksdb_env_t* env,
                                                            const char* path,
                                                            char** errptr);
-extern C_ROCKSDB_LIBRARY_API unsigned char crocksdb_env_is_db_locked(crocksdb_env_t* env, const char* path, char** errptr);
+extern C_ROCKSDB_LIBRARY_API unsigned char crocksdb_env_is_db_locked(
+    crocksdb_env_t* env, const char* path, char** errptr);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_env_destroy(crocksdb_env_t*);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_envoptions_t*

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1686,6 +1686,7 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_env_file_exists(crocksdb_env_t* env,
 extern C_ROCKSDB_LIBRARY_API void crocksdb_env_delete_file(crocksdb_env_t* env,
                                                            const char* path,
                                                            char** errptr);
+extern C_ROCKSDB_LIBRARY_API unsigned char crocksdb_env_is_db_locked(crocksdb_env_t* env, const char* path, char** errptr);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_env_destroy(crocksdb_env_t*);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_envoptions_t*

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1686,7 +1686,11 @@ extern "C" {
     ) -> *mut DBEnv;
     pub fn crocksdb_env_file_exists(env: *mut DBEnv, path: *const c_char, err: *mut *mut c_char);
     pub fn crocksdb_env_delete_file(env: *mut DBEnv, path: *const c_char, err: *mut *mut c_char);
-    pub fn crocksdb_env_is_db_locked(env: *mut DBEnv, path: *const c_char, err: *mut *mut c_char) -> bool;
+    pub fn crocksdb_env_is_db_locked(
+        env: *mut DBEnv,
+        path: *const c_char,
+        err: *mut *mut c_char,
+    ) -> bool;
     pub fn crocksdb_env_destroy(env: *mut DBEnv);
     pub fn crocksdb_env_set_background_threads(env: *mut DBEnv, n: c_int);
     pub fn crocksdb_env_set_high_priority_background_threads(env: *mut DBEnv, n: c_int);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1686,6 +1686,7 @@ extern "C" {
     ) -> *mut DBEnv;
     pub fn crocksdb_env_file_exists(env: *mut DBEnv, path: *const c_char, err: *mut *mut c_char);
     pub fn crocksdb_env_delete_file(env: *mut DBEnv, path: *const c_char, err: *mut *mut c_char);
+    pub fn crocksdb_env_is_db_locked(env: *mut DBEnv, path: *const c_char, err: *mut *mut c_char) -> bool;
     pub fn crocksdb_env_destroy(env: *mut DBEnv);
     pub fn crocksdb_env_set_background_threads(env: *mut DBEnv, n: c_int);
     pub fn crocksdb_env_set_high_priority_background_threads(env: *mut DBEnv, n: c_int);

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2724,6 +2724,14 @@ impl Env {
         }
     }
 
+    pub fn is_db_locked(&self, path: &str) -> Result<bool, String> {
+        unsafe {
+            let file_path = CString::new(path).unwrap();
+            let locked = ffi_try!(crocksdb_env_is_db_locked(self.inner, file_path.as_ptr()));
+            Ok(locked)
+        }
+    }
+
     pub fn set_background_threads(&self, n: i32) {
         unsafe {
             crocksdb_ffi::crocksdb_env_set_background_threads(self.inner, n);

--- a/tests/cases/test_column_family.rs
+++ b/tests/cases/test_column_family.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-use rocksdb::{ColumnFamilyOptions, DBOptions, MergeOperands, Writable, DB, Env};
+use rocksdb::{ColumnFamilyOptions, DBOptions, Env, MergeOperands, Writable, DB};
 
 use super::tempdir_with_prefix;
 
@@ -162,7 +162,9 @@ fn test_db_lock() {
     let temp = tempdir_with_prefix("_rust_rocksdb_test_open_for_read_only");
     let path = temp.path().to_str().unwrap();
     let env = Env::default();
-    assert!(env.is_db_locked(temp.path().join("non-exist").to_str().unwrap()).is_err());
+    assert!(env
+        .is_db_locked(temp.path().join("non-exist").to_str().unwrap())
+        .is_err());
 
     let mut opts = DBOptions::new();
     opts.create_if_missing(true);

--- a/tests/cases/test_column_family.rs
+++ b/tests/cases/test_column_family.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-use rocksdb::{ColumnFamilyOptions, DBOptions, MergeOperands, Writable, DB};
+use rocksdb::{ColumnFamilyOptions, DBOptions, MergeOperands, Writable, DB, Env};
 
 use super::tempdir_with_prefix;
 
@@ -155,4 +155,22 @@ pub fn test_column_family_option_use_doubly_skiplist() {
     cf_opts.set_doubly_skiplist();
     let memtable_name = cf_opts.get_memtable_factory_name();
     assert_eq!("DoublySkipListFactory", memtable_name.unwrap());
+}
+
+#[test]
+fn test_db_lock() {
+    let temp = tempdir_with_prefix("_rust_rocksdb_test_open_for_read_only");
+    let path = temp.path().to_str().unwrap();
+    let env = Env::default();
+    assert!(env.is_db_locked(temp.path().join("non-exist").to_str().unwrap()).is_err());
+
+    let mut opts = DBOptions::new();
+    opts.create_if_missing(true);
+    let db = DB::open_default(path).unwrap();
+    assert_eq!(env.is_db_locked(path), Ok(true));
+    drop(db);
+    assert_eq!(env.is_db_locked(path), Ok(false));
+
+    let r1 = DB::open_for_read_only(opts.clone(), path, false).unwrap();
+    assert_eq!(env.is_db_locked(path), Ok(false));
 }


### PR DESCRIPTION
This is useful to detect whether a DB is still hold by other threads.

We may also use reference check to detect whether a DB is obsolete,
but checking the file lock directly provides more safety.