### PR TITLE
update some enums

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2501,8 +2501,15 @@ struct crocksdb_eventlistener_t : public EventListener {
       case BackgroundErrorReason::kMemTable:
         r = crocksdb_backgrounderrorreason_t::kMemTable;
         break;
-      default:
-        assert(false);
+      case BackgroundErrorReason::kManifestWrite:
+        r = crocksdb_backgrounderrorreason_t::kManifestWrite;
+        break;
+      case BackgroundErrorReason::kFlushNoWAL:
+        r = crocksdb_backgrounderrorreason_t::kFlushNoWAL;
+        break;
+      case BackgroundErrorReason::kManifestWriteNoWAL:
+        r = crocksdb_backgrounderrorreason_t::kManifestWriteNoWAL;
+        break;
     }
     crocksdb_status_ptr_t* s = new crocksdb_status_ptr_t;
     s->rep = status;
@@ -4327,8 +4334,6 @@ crocksdb_encryption_method_t crocksdb_file_encryption_info_method(
       return crocksdb_encryption_method_t::kAES256_CTR;
     case EncryptionMethod::kSM4_CTR:
       return crocksdb_encryption_method_t::kSM4_CTR;
-    default:
-      assert(false);
   }
 }
 
@@ -4373,8 +4378,6 @@ void crocksdb_file_encryption_info_set_method(
     case kSM4_CTR:
       file_info->rep->method = EncryptionMethod::kSM4_CTR;
       break;
-    default:
-      assert(false);
   };
 }
 
@@ -5250,13 +5253,23 @@ struct crocksdb_table_properties_t {
 };
 
 uint64_t crocksdb_table_properties_get_u64(
-    const crocksdb_table_properties_t* props, crocksdb_table_property_t prop) {
+    const crocksdb_table_properties_t* props, crocksdb_table_u64_property_t prop) {
   const TableProperties& rep = props->rep;
   switch (prop) {
+    case kOriginalFileNumber:
+      return rep.orig_file_number;
     case kDataSize:
       return rep.data_size;
     case kIndexSize:
       return rep.index_size;
+    case kIndexPartitions:
+      return rep.index_partitions;
+    case kTopLevelIndexSize:
+      return rep.top_level_index_size;
+    case kIndexKeyIsUserKey:
+      return rep.index_key_is_user_key;
+    case kIndexValueIsDeltaEncoded:
+      return rep.index_value_is_delta_encoded;
     case kFilterSize:
       return rep.filter_size;
     case kRawKeySize:
@@ -5267,22 +5280,49 @@ uint64_t crocksdb_table_properties_get_u64(
       return rep.num_data_blocks;
     case kNumEntries:
       return rep.num_entries;
+    case kNumFilterEntries:
+      return rep.num_filter_entries;
+    case kNumDeletions:
+      return rep.num_deletions;
+    case kNumMergeOperands:
+      return rep.num_merge_operands;
+    case kNumRangeDeletions:
+      return rep.num_range_deletions;
     case kFormatVersion:
       return rep.format_version;
     case kFixedKeyLen:
-      return rep.data_size;
-    case kColumnFamilyID:
+      return rep.fixed_key_len;
+    case kColumnFamilyId:
       return rep.column_family_id;
+    case kCreationTime:
+      return rep.creation_time;
+    case kOldestKeyTime:
+      return rep.oldest_key_time;
+    case kFileCreationTime:
+      return rep.file_creation_time;
+    case kSlowCompressionEstimatedDataSize:
+      return rep.slow_compression_estimated_data_size;
+    case kFastCompressionEstimatedDataSize:
+      return rep.fast_compression_estimated_data_size;
     default:
-      return 0;
+      assert(false);
   }
 }
 
 const char* crocksdb_table_properties_get_str(
-    const crocksdb_table_properties_t* props, crocksdb_table_property_t prop,
+    const crocksdb_table_properties_t* props, crocksdb_table_str_property_t prop,
     size_t* slen) {
   const TableProperties& rep = props->rep;
   switch (prop) {
+    case kDbId:
+      *slen = rep.db_id.size();
+      return rep.db_id.data();
+    case kDbSessionId:
+      *slen = rep.db_session_id.size();
+      return rep.db_session_id.data();
+    case kDbHostId:
+      *slen = rep.db_host_id.size();
+      return rep.db_host_id.data();
     case kColumnFamilyName:
       *slen = rep.column_family_name.size();
       return rep.column_family_name.data();
@@ -5304,8 +5344,11 @@ const char* crocksdb_table_properties_get_str(
     case kCompressionName:
       *slen = rep.compression_name.size();
       return rep.compression_name.data();
+    case kCompressionOptions:
+      *slen = rep.compression_options.size();
+      return rep.compression_options.data();
     default:
-      return nullptr;
+      assert(false);
   }
 }
 

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -182,7 +182,7 @@ typedef struct crocksdb_sst_partitioner_context_t
 typedef struct crocksdb_sst_partitioner_factory_t
     crocksdb_sst_partitioner_factory_t;
 
-typedef enum crocksdb_table_property_t {
+typedef enum crocksdb_table_u64_property_t {
   kDataSize = 1,
   kIndexSize = 2,
   kFilterSize = 3,
@@ -192,15 +192,36 @@ typedef enum crocksdb_table_property_t {
   kNumEntries = 7,
   kFormatVersion = 8,
   kFixedKeyLen = 9,
-  kColumnFamilyID = 10,
-  kColumnFamilyName = 11,
-  kFilterPolicyName = 12,
-  kComparatorName = 13,
-  kMergeOperatorName = 14,
-  kPrefixExtractorName = 15,
-  kPropertyCollectorsNames = 16,
-  kCompressionName = 17,
-} crocksdb_table_property_t;
+  kColumnFamilyId = 10,
+  kOriginalFileNumber = 11,
+  kIndexPartitions = 12,
+  kTopLevelIndexSize = 13,
+  kIndexKeyIsUserKey = 14,
+  kIndexValueIsDeltaEncoded = 15,
+  kNumFilterEntries = 16,
+  kNumDeletions = 17,
+  kNumMergeOperands = 18,
+  kNumRangeDeletions = 19,
+  kCreationTime = 20,
+  kOldestKeyTime = 21,
+  kFileCreationTime = 22,
+  kSlowCompressionEstimatedDataSize = 23,
+  kFastCompressionEstimatedDataSize = 24,
+} crocksdb_table_u64_property_t;
+
+typedef enum crocksdb_table_str_property_t {
+  kDbId = 1,
+  kDbSessionId = 2,
+  kDbHostId = 3,
+  kFilterPolicyName = 4,
+  kColumnFamilyName = 5,
+  kComparatorName = 6,
+  kMergeOperatorName = 7,
+  kPrefixExtractorName = 8,
+  kPropertyCollectorsNames = 9,
+  kCompressionName = 10,
+  kCompressionOptions = 11,
+} crocksdb_table_str_property_t;
 
 typedef enum crocksdb_ratelimiter_mode_t {
   kReadsOnly = 1,
@@ -213,6 +234,9 @@ typedef enum crocksdb_backgrounderrorreason_t {
   kCompaction = 2,
   kWriteCallback = 3,
   kMemTable = 4,
+  kManifestWrite = 5,
+  kFlushNoWAL = 6,
+  kManifestWriteNoWAL = 7,
 } crocksdb_backgrounderrorreason_t;
 
 #ifdef OPENSSL
@@ -2058,10 +2082,10 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_get_supported_compression(int*,
 /* Table Properties */
 
 extern C_ROCKSDB_LIBRARY_API uint64_t crocksdb_table_properties_get_u64(
-    const crocksdb_table_properties_t*, crocksdb_table_property_t prop);
+    const crocksdb_table_properties_t*, crocksdb_table_u64_property_t prop);
 
 extern C_ROCKSDB_LIBRARY_API const char* crocksdb_table_properties_get_str(
-    const crocksdb_table_properties_t*, crocksdb_table_property_t prop,
+    const crocksdb_table_properties_t*, crocksdb_table_str_property_t prop,
     size_t* slen);
 
 extern C_ROCKSDB_LIBRARY_API const crocksdb_user_collected_properties_t*

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -355,9 +355,10 @@ pub enum DBInfoLogLevel {
     NumInfoLog = 6,
 }
 
+// @needs_manual_sync
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(C)]
-pub enum DBTableProperty {
+pub enum DBTableU64Property {
     DataSize = 1,
     IndexSize = 2,
     FilterSize = 3,
@@ -368,13 +369,37 @@ pub enum DBTableProperty {
     FormatVersion = 8,
     FixedKeyLen = 9,
     ColumnFamilyId = 10,
-    ColumnFamilyName = 11,
-    FilterPolicyName = 12,
-    ComparatorName = 13,
-    MergeOperatorName = 14,
-    PrefixExtractorName = 15,
-    PropertyCollectorsNames = 16,
-    CompressionName = 17,
+    OriginalFileNumber = 11,
+    IndexPartitions = 12,
+    TopLevelIndexSize = 13,
+    IndexKeyIsUserKey = 14,
+    IndexValueIsDeltaEncoded = 15,
+    NumFilterEntries = 16,
+    NumDeletions = 17,
+    NumMergeOperands = 18,
+    NumRangeDeletions = 19,
+    CreationTime = 20,
+    OldestKeyTime = 21,
+    FileCreationTime = 22,
+    SlowCompressionEstimatedDataSize = 23,
+    FastCompressionEstimatedDataSize = 24,
+}
+
+// @needs_manual_sync
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub enum DBTableStrProperty {
+    DbId = 1,
+    DbSessionId = 2,
+    DbHostId = 3,
+    FilterPolicyName = 4,
+    ColumnFamilyName = 5,
+    ComparatorName = 6,
+    MergeOperatorName = 7,
+    PrefixExtractorName = 8,
+    PropertyCollectorsNames = 9,
+    CompressionName = 10,
+    CompressionOptions = 11,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -2124,12 +2149,12 @@ extern "C" {
 
     pub fn crocksdb_table_properties_get_u64(
         props: *const DBTableProperties,
-        prop: DBTableProperty,
+        prop: DBTableU64Property,
     ) -> u64;
 
     pub fn crocksdb_table_properties_get_str(
         props: *const DBTableProperties,
-        prop: DBTableProperty,
+        prop: DBTableStrProperty,
         slen: *mut size_t,
     ) -> *const u8;
 

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -13,7 +13,7 @@
 
 use crocksdb_ffi::{
     self, DBTableProperties, DBTablePropertiesCollection, DBTablePropertiesCollectionIterator,
-    DBTableProperty, DBUserCollectedProperties, DBUserCollectedPropertiesIterator,
+    DBTableU64Property, DBTableStrProperty, DBUserCollectedProperties, DBUserCollectedPropertiesIterator,
 };
 use libc::size_t;
 use std::marker::PhantomData;
@@ -140,11 +140,11 @@ impl TableProperties {
         &*(ptr as *const TableProperties)
     }
 
-    fn get_u64(&self, prop: DBTableProperty) -> u64 {
+    fn get_u64(&self, prop: DBTableU64Property) -> u64 {
         unsafe { crocksdb_ffi::crocksdb_table_properties_get_u64(&self.inner, prop) }
     }
 
-    fn get_str(&self, prop: DBTableProperty) -> &str {
+    fn get_str(&self, prop: DBTableStrProperty) -> &str {
         unsafe {
             let mut slen: size_t = 0;
             let s = crocksdb_ffi::crocksdb_table_properties_get_str(&self.inner, prop, &mut slen);
@@ -154,71 +154,71 @@ impl TableProperties {
     }
 
     pub fn data_size(&self) -> u64 {
-        self.get_u64(DBTableProperty::DataSize)
+        self.get_u64(DBTableU64Property::DataSize)
     }
 
     pub fn index_size(&self) -> u64 {
-        self.get_u64(DBTableProperty::IndexSize)
+        self.get_u64(DBTableU64Property::IndexSize)
     }
 
     pub fn filter_size(&self) -> u64 {
-        self.get_u64(DBTableProperty::FilterSize)
+        self.get_u64(DBTableU64Property::FilterSize)
     }
 
     pub fn raw_key_size(&self) -> u64 {
-        self.get_u64(DBTableProperty::RawKeySize)
+        self.get_u64(DBTableU64Property::RawKeySize)
     }
 
     pub fn raw_value_size(&self) -> u64 {
-        self.get_u64(DBTableProperty::RawValueSize)
+        self.get_u64(DBTableU64Property::RawValueSize)
     }
 
     pub fn num_data_blocks(&self) -> u64 {
-        self.get_u64(DBTableProperty::NumDataBlocks)
+        self.get_u64(DBTableU64Property::NumDataBlocks)
     }
 
     pub fn num_entries(&self) -> u64 {
-        self.get_u64(DBTableProperty::NumEntries)
+        self.get_u64(DBTableU64Property::NumEntries)
     }
 
     pub fn format_version(&self) -> u64 {
-        self.get_u64(DBTableProperty::FormatVersion)
+        self.get_u64(DBTableU64Property::FormatVersion)
     }
 
     pub fn fixed_key_len(&self) -> u64 {
-        self.get_u64(DBTableProperty::FixedKeyLen)
+        self.get_u64(DBTableU64Property::FixedKeyLen)
     }
 
     pub fn column_family_id(&self) -> u64 {
-        self.get_u64(DBTableProperty::ColumnFamilyId)
+        self.get_u64(DBTableU64Property::ColumnFamilyId)
     }
 
     pub fn column_family_name(&self) -> &str {
-        self.get_str(DBTableProperty::ColumnFamilyName)
+        self.get_str(DBTableStrProperty::ColumnFamilyName)
     }
 
     pub fn filter_policy_name(&self) -> &str {
-        self.get_str(DBTableProperty::FilterPolicyName)
+        self.get_str(DBTableStrProperty::FilterPolicyName)
     }
 
     pub fn comparator_name(&self) -> &str {
-        self.get_str(DBTableProperty::ComparatorName)
+        self.get_str(DBTableStrProperty::ComparatorName)
     }
 
     pub fn merge_operator_name(&self) -> &str {
-        self.get_str(DBTableProperty::MergeOperatorName)
+        self.get_str(DBTableStrProperty::MergeOperatorName)
     }
 
     pub fn prefix_extractor_name(&self) -> &str {
-        self.get_str(DBTableProperty::PrefixExtractorName)
+        self.get_str(DBTableStrProperty::PrefixExtractorName)
     }
 
     pub fn property_collectors_names(&self) -> &str {
-        self.get_str(DBTableProperty::PropertyCollectorsNames)
+        self.get_str(DBTableStrProperty::PropertyCollectorsNames)
     }
 
     pub fn compression_name(&self) -> &str {
-        self.get_str(DBTableProperty::CompressionName)
+        self.get_str(DBTableStrProperty::CompressionName)
     }
 
     pub fn user_collected_properties(&self) -> &UserCollectedProperties {

--- a/src/table_properties_rc.rs
+++ b/src/table_properties_rc.rs
@@ -6,7 +6,7 @@
 //! the collection stay valid for the lifetime of the collection, it doesn't
 //! guarantee that the _DB_ stays valid for the lifetime of the collection.
 
-use crocksdb_ffi::{DBTablePropertiesCollection, DBTableProperty};
+use crocksdb_ffi::{DBTablePropertiesCollection, DBTableU64Property};
 use libc::size_t;
 use librocksdb_sys as crocksdb_ffi;
 use std::ops::Deref;
@@ -140,12 +140,12 @@ impl TableProperties {
         TableProperties { handle }
     }
 
-    fn get_u64(&self, prop: DBTableProperty) -> u64 {
+    fn get_u64(&self, prop: DBTableU64Property) -> u64 {
         unsafe { crocksdb_ffi::crocksdb_table_properties_get_u64(self.handle.ptr(), prop) }
     }
 
     pub fn num_entries(&self) -> u64 {
-        self.get_u64(DBTableProperty::NumEntries)
+        self.get_u64(DBTableU64Property::NumEntries)
     }
 
     pub fn user_collected_properties(&self) -> UserCollectedProperties {


### PR DESCRIPTION
Also remove some redundant `default:` in switch case expression, so that it can raise warning if RocksDB side changes again. Note that not all `default:` can be removed because C++ allows bit-and variants for pre-c++11 enums.

Signed-off-by: tabokie <xy.tao@outlook.com>