### PR TITLE
Update rust-bindgen to fix build with clang 16

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -30,7 +30,7 @@ static_libcpp = []
 [build-dependencies]
 cc = "1.0.3"
 cmake = "0.1"
-bindgen = { version = "0.57", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.65", default-features = false, features = ["runtime"] }
 
 [dependencies.tikv-jemalloc-sys]
 version = "0.5.0"


### PR DESCRIPTION
Close #750 

After some searching, I found two similar issues https://github.com/rust-lang/rust-bindgen/issues/2488 and https://github.com/rust-lang/rust-bindgen/issues/2312.
This issue has been fixed in rust-bindgen 0.62.
