### PR TITLE
Support get sequence number from UnsafeSnap

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -433,7 +433,7 @@ impl<D: Deref<Target = DB>> Snapshot<D> {
 
     /// Get the snapshot's sequence number.
     pub fn get_sequence_number(&self) -> u64 {
-        unsafe { crocksdb_ffi::crocksdb_get_snapshot_sequence_number(self.snap.get_inner()) }
+        unsafe { self.snap.get_sequence_number() }
     }
 }
 

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -532,6 +532,11 @@ impl UnsafeSnap {
     pub unsafe fn get_inner(&self) -> *const DBSnapshot {
         self.inner
     }
+
+    /// Get the snapshot's sequence number.
+    pub unsafe fn get_sequence_number(&self) -> u64 {
+        crocksdb_ffi::crocksdb_get_snapshot_sequence_number(self.get_inner())
+    }
 }
 
 pub struct ReadOptions {


### PR DESCRIPTION
As title, this is a candidate solution to implement coprocessor cache for raftstore v2.