### PR TITLE
[cherry-pick] port ttl and periodic_compaction_seconds in ColumnFamilyOptions

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3321,10 +3321,73 @@ unsigned char crocksdb_options_get_force_consistency_checks(
   return opt->rep.force_consistency_checks;
 }
 
-char* crocksdb_options_statistics_get_string(crocksdb_options_t* opt) {
-  if (opt->rep.statistics) {
-    rocksdb::Statistics* statistics = opt->rep.statistics.get();
-    return strdup(statistics->ToString().c_str());
+void crocksdb_options_set_ttl(crocksdb_options_t* opt, uint64_t ttl) {
+  opt->rep.ttl = ttl;
+}
+
+uint64_t crocksdb_options_get_ttl(const crocksdb_options_t* opt) {
+  return opt->rep.ttl;
+}
+
+void crocksdb_options_set_periodic_compaction_seconds(crocksdb_options_t* opt,
+                                                      uint64_t seconds) {
+  opt->rep.periodic_compaction_seconds = seconds;
+}
+
+uint64_t crocksdb_options_get_periodic_compaction_seconds(
+    const crocksdb_options_t* opt) {
+  return opt->rep.periodic_compaction_seconds;
+}
+
+void crocksdb_options_set_statistics(crocksdb_options_t* opt,
+                                     crocksdb_statistics_t* statistics) {
+  opt->rep.statistics = statistics->rep;
+}
+crocksdb_statistics_t* crocksdb_options_get_statistics(
+    crocksdb_options_t* opt) {
+  crocksdb_statistics_t* statistics = new crocksdb_statistics_t;
+  statistics->rep = opt->rep.statistics;
+  return statistics;
+}
+
+crocksdb_statistics_t* crocksdb_statistics_create() {
+  crocksdb_statistics_t* statistics = new crocksdb_statistics_t;
+  statistics->rep = rocksdb::CreateDBStatistics();
+  return statistics;
+}
+
+crocksdb_statistics_t* crocksdb_titan_statistics_create() {
+  crocksdb_statistics_t* statistics = new crocksdb_statistics_t;
+  statistics->rep = rocksdb::titandb::CreateDBStatistics();
+  return statistics;
+}
+
+crocksdb_statistics_t* crocksdb_empty_statistics_create() {
+  crocksdb_statistics_t* statistics = new crocksdb_statistics_t;
+  statistics->rep = nullptr;
+  return statistics;
+}
+
+void crocksdb_statistics_destroy(crocksdb_statistics_t* statistics) {
+  if (statistics->rep) {
+    statistics->rep.reset();
+  }
+  delete statistics;
+}
+
+unsigned char crocksdb_statistics_is_empty(crocksdb_statistics_t* statistics) {
+  return statistics->rep == nullptr;
+}
+
+void crocksdb_statistics_reset(crocksdb_statistics_t* statistics) {
+  if (statistics->rep) {
+    statistics->rep->Reset();
+  }
+}
+
+char* crocksdb_statistics_to_string(crocksdb_statistics_t* statistics) {
+  if (statistics->rep) {
+    return strdup(statistics->rep->ToString().c_str());
   }
   return nullptr;
 }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3321,6 +3321,14 @@ unsigned char crocksdb_options_get_force_consistency_checks(
   return opt->rep.force_consistency_checks;
 }
 
+char* crocksdb_options_statistics_get_string(crocksdb_options_t* opt) {
+  if (opt->rep.statistics) {
+    rocksdb::Statistics* statistics = opt->rep.statistics.get();
+    return strdup(statistics->ToString().c_str());
+  }
+  return nullptr;
+}
+
 void crocksdb_options_set_ttl(crocksdb_options_t* opt, uint64_t ttl) {
   opt->rep.ttl = ttl;
 }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3339,59 +3339,6 @@ uint64_t crocksdb_options_get_periodic_compaction_seconds(
   return opt->rep.periodic_compaction_seconds;
 }
 
-void crocksdb_options_set_statistics(crocksdb_options_t* opt,
-                                     crocksdb_statistics_t* statistics) {
-  opt->rep.statistics = statistics->rep;
-}
-crocksdb_statistics_t* crocksdb_options_get_statistics(
-    crocksdb_options_t* opt) {
-  crocksdb_statistics_t* statistics = new crocksdb_statistics_t;
-  statistics->rep = opt->rep.statistics;
-  return statistics;
-}
-
-crocksdb_statistics_t* crocksdb_statistics_create() {
-  crocksdb_statistics_t* statistics = new crocksdb_statistics_t;
-  statistics->rep = rocksdb::CreateDBStatistics();
-  return statistics;
-}
-
-crocksdb_statistics_t* crocksdb_titan_statistics_create() {
-  crocksdb_statistics_t* statistics = new crocksdb_statistics_t;
-  statistics->rep = rocksdb::titandb::CreateDBStatistics();
-  return statistics;
-}
-
-crocksdb_statistics_t* crocksdb_empty_statistics_create() {
-  crocksdb_statistics_t* statistics = new crocksdb_statistics_t;
-  statistics->rep = nullptr;
-  return statistics;
-}
-
-void crocksdb_statistics_destroy(crocksdb_statistics_t* statistics) {
-  if (statistics->rep) {
-    statistics->rep.reset();
-  }
-  delete statistics;
-}
-
-unsigned char crocksdb_statistics_is_empty(crocksdb_statistics_t* statistics) {
-  return statistics->rep == nullptr;
-}
-
-void crocksdb_statistics_reset(crocksdb_statistics_t* statistics) {
-  if (statistics->rep) {
-    statistics->rep->Reset();
-  }
-}
-
-char* crocksdb_statistics_to_string(crocksdb_statistics_t* statistics) {
-  if (statistics->rep) {
-    return strdup(statistics->rep->ToString().c_str());
-  }
-  return nullptr;
-}
-
 uint64_t crocksdb_options_statistics_get_ticker_count(crocksdb_options_t* opt,
                                                       uint32_t ticker_type) {
   if (opt->rep.statistics) {

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1399,6 +1399,17 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_force_consistency_checks(
 extern C_ROCKSDB_LIBRARY_API unsigned char
 crocksdb_options_get_force_consistency_checks(crocksdb_options_t*);
 
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_ttl(
+    crocksdb_options_t* opt, uint64_t ttl);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_options_get_ttl(const crocksdb_options_t* opt);
+
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_options_set_periodic_compaction_seconds(crocksdb_options_t* opt,
+                                                 uint64_t seconds);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_options_get_periodic_compaction_seconds(const crocksdb_options_t* opt);
+
 /* RateLimiter */
 extern C_ROCKSDB_LIBRARY_API crocksdb_ratelimiter_t*
 crocksdb_ratelimiter_create(int64_t rate_bytes_per_sec,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -889,6 +889,11 @@ extern "C" {
         err: *mut *mut c_char,
     );
     pub fn crocksdb_options_get_block_cache_capacity(options: *const Options) -> usize;
+    pub fn crocksdb_options_set_ttl(options: *mut Options, ttl_secs: u64);
+    pub fn crocksdb_options_get_ttl(options: *const Options) -> u64;
+    pub fn crocksdb_options_set_periodic_compaction_seconds(options: *mut Options, secs: u64);
+    pub fn crocksdb_options_get_periodic_compaction_seconds(options: *const Options) -> u64;
+
     pub fn crocksdb_load_latest_options(
         dbpath: *const c_char,
         env: *mut DBEnv,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1970,6 +1970,26 @@ impl ColumnFamilyOptions {
             );
         }
     }
+
+    pub fn set_ttl(&mut self, ttl_secs: u64) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_ttl(self.inner, ttl_secs);
+        }
+    }
+
+    pub fn get_ttl(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_options_get_ttl(self.inner) }
+    }
+
+    pub fn set_periodic_compaction_seconds(&mut self, secs: u64) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_periodic_compaction_seconds(self.inner, secs);
+        }
+    }
+
+    pub fn get_periodic_compaction_seconds(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_options_get_periodic_compaction_seconds(self.inner) }
+    }
 }
 
 // ColumnFamilyDescriptor is a pair of column family's name and options.

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -945,3 +945,17 @@ fn test_compact_on_deletion() {
     assert_eq!(db.get_property_int(&level0_prop).unwrap(), 0);
     assert_eq!(db.get_property_int(&level1_prop).unwrap(), 1);
 }
+
+#[test]
+fn test_ttl_compaction_options() {
+    let path = tempdir_with_prefix("_rust_rocksdb_ttl_compaction_options");
+    let path_str = path.path().to_str().unwrap();
+    let mut opts = DBOptions::new();
+    opts.create_if_missing(true);
+    let mut cf_opts = ColumnFamilyOptions::new();
+    cf_opts.set_ttl(3600);
+    cf_opts.set_periodic_compaction_seconds(7200);
+    let db = DB::open_cf(opts, path_str, vec![("default", cf_opts)]).unwrap();
+    assert_eq!(db.get_options().get_ttl(), 3600);
+    assert_eq!(db.get_options().get_periodic_compaction_seconds(), 7200);
+}


### PR DESCRIPTION
This is a cherry-pick pr from https://github.com/tikv/rust-rocksdb/pull/749.