### PR TITLE
Fix skipping compaction filter logic when titan is enabled

### DIFF
--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -361,6 +361,8 @@ mod tests {
     use std::sync::mpsc::{self, SyncSender};
     use std::time::Duration;
 
+    use crate::CompactionFilterDecision;
+    use crate::CompactionFilterValueType;
     use librocksdb_sys::DBTableFileCreationReason;
 
     use crate::{
@@ -417,8 +419,15 @@ mod tests {
 
     struct FlushFilter;
     impl CompactionFilter for FlushFilter {
-        fn filter(&mut self, _: usize, _: &[u8], _: &[u8], _: &mut Vec<u8>, _: &mut bool) -> bool {
-            true
+        fn unsafe_filter(
+            &mut self,
+            _: usize,
+            _: &[u8],
+            _: u64,
+            _: &[u8],
+            _: CompactionFilterValueType,
+        ) -> CompactionFilterDecision {
+            CompactionFilterDecision::Remove
         }
     }
 


### PR DESCRIPTION
https://github.com/tikv/rust-rocksdb/pull/757 changes the interface of compaction filter, but Titan doesn't. When titan is enabled, it wraps the tikv compaction filter. But Titan only overrides the `FilterV3` but `UnsafeFilter`. So every calling to `UnsafeFilter` would just call the default implement of the base compaction filter which turns out skipping the logic of tikv compaction filter.

This PR includes the interface changes on Titan side https://github.com/tikv/tikv/pull/16054