### PR TITLE
librocksdb_sys: no longer static links OpenSSL for encryption (#774)

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -10,7 +10,7 @@ bzip2-sys = { version = "0.1.11+1.0.8", features = ["static"] }
 libc = "0.2.11"
 libtitan_sys = { path = "libtitan_sys" }
 libz-sys = { version = "1.1", features = ["static"] }
-openssl-sys = { version = "0.9.54", optional = true, features = ["vendored"] }
+openssl-sys = { version = "0.9.54", optional = true }
 zstd-sys = "2.0.1+zstd.1.5.2"
 lz4-sys = "1.9"
 

--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -130,7 +130,6 @@ fn build_rocksdb() -> Build {
     let mut cfg = Config::new("rocksdb");
     if cfg!(feature = "encryption") {
         cfg.register_dep("OPENSSL").define("WITH_OPENSSL", "ON");
-        println!("cargo:rustc-link-lib=static=crypto");
     }
     if cfg!(feature = "jemalloc") && NO_JEMALLOC_TARGETS.iter().all(|i| !target.contains(i)) {
         cfg.register_dep("JEMALLOC").define("WITH_JEMALLOC", "ON");


### PR DESCRIPTION
Cherry-pick #774

---
Previously, enabling encryption in librocksdb_sys resulted in static linking of OpenSSL, potentially preventing users from utilizing their host system's OpenSSL with important security updates.
This commit removes the requirement for static linking, giving users the flexibility to choose whether to use it or not.