### PR TITLE
Expose bottommost_file_compaction_delay option

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3377,6 +3377,16 @@ uint64_t crocksdb_options_get_periodic_compaction_seconds(
   return opt->rep.periodic_compaction_seconds;
 }
 
+void crocksdb_options_set_bottommost_file_compaction_delay(
+    crocksdb_options_t* opt, uint32_t delay) {
+  opt->rep.bottommost_file_compaction_delay = delay;
+}
+
+uint32_t crocksdb_options_get_bottommost_file_compaction_delay(
+    const crocksdb_options_t* opt) {
+  return opt->rep.bottommost_file_compaction_delay;
+}
+
 void crocksdb_options_set_statistics(crocksdb_options_t* opt,
                                      crocksdb_statistics_t* statistics) {
   opt->rep.statistics = statistics->rep;

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1465,6 +1465,13 @@ crocksdb_options_set_periodic_compaction_seconds(crocksdb_options_t* opt,
 extern C_ROCKSDB_LIBRARY_API uint64_t
 crocksdb_options_get_periodic_compaction_seconds(const crocksdb_options_t* opt);
 
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_options_set_bottommost_file_compaction_delay(crocksdb_options_t* opt,
+                                                      uint32_t delay);
+extern C_ROCKSDB_LIBRARY_API uint32_t
+crocksdb_options_get_bottommost_file_compaction_delay(
+    const crocksdb_options_t* opt);
+
 /* RateLimiter */
 extern C_ROCKSDB_LIBRARY_API crocksdb_ratelimiter_t*
 crocksdb_ratelimiter_create(int64_t rate_bytes_per_sec,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -979,6 +979,8 @@ extern "C" {
     pub fn crocksdb_options_get_ttl(options: *const Options) -> u64;
     pub fn crocksdb_options_set_periodic_compaction_seconds(options: *mut Options, secs: u64);
     pub fn crocksdb_options_get_periodic_compaction_seconds(options: *const Options) -> u64;
+    pub fn crocksdb_options_set_bottommost_file_compaction_delay(options: *mut Options, secs: u32);
+    pub fn crocksdb_options_get_bottommost_file_compaction_delay(options: *const Options) -> u32;
 
     pub fn crocksdb_load_latest_options(
         dbpath: *const c_char,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -2102,6 +2102,16 @@ impl ColumnFamilyOptions {
             Some(WriteBufferManager { inner: manager })
         }
     }
+
+    pub fn set_bottommost_file_compaction_delay(&mut self, delay: u32) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_bottommost_file_compaction_delay(self.inner, delay);
+        }
+    }
+
+    pub fn get_bottommost_file_compaction_delay(&self) -> u32 {
+        unsafe { crocksdb_ffi::crocksdb_options_get_bottommost_file_compaction_delay(self.inner) }
+    }
 }
 
 // ColumnFamilyDescriptor is a pair of column family's name and options.

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -974,3 +974,21 @@ fn test_ttl_compaction_options() {
     assert_eq!(db.get_options().get_ttl(), 3600);
     assert_eq!(db.get_options().get_periodic_compaction_seconds(), 7200);
 }
+
+#[test]
+fn test_bottommost_file_compaction_delay() {
+    let path = tempdir_with_prefix("_rust_rocksdb_bottommost_file_compaction_delay");
+    let path_str = path.path().to_str().unwrap();
+    let mut opts = DBOptions::new();
+    opts.create_if_missing(true);
+    let mut cf_opts = ColumnFamilyOptions::new();
+    cf_opts.set_bottommost_file_compaction_delay(100);
+    let db = DB::open_cf(opts, path_str, vec![("default", cf_opts)]).unwrap();
+    assert_eq!(db.get_options().get_bottommost_file_compaction_delay(), 100);
+
+    let cf = db.cf_handle("default").unwrap();
+
+    db.set_options_cf(cf, &[("bottommost_file_compaction_delay", "200")])
+        .unwrap();
+    assert_eq!(db.get_options().get_bottommost_file_compaction_delay(), 200);
+}


### PR DESCRIPTION
When we upgrade RocksDB from 6.29 to 8.10, we did not cherry-pick https://github.com/tikv/rocksdb/commit/40551e21c637c88393cceb5fc662c72ff158545e. Because there was a different solution proposed by Facebook https://github.com/facebook/rocksdb/pull/11701. This PR exposes the option, so that TiKV can tune this when potential regressions are observed.