### PR TITLE
Fix RocksDB compilation due to VLA in 6.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
-	url = https://github.com/tikv/rocksdb.git
-	branch = tikv-6.5 
+	url = https://github.com/v01dstar/rocksdb.git
+	branch = fix-compile-6.5
 
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan


### PR DESCRIPTION
Fixing CSE compilation error with modern toolchain, e.g. Apple clang 17+