### PR TITLE
compaction_opt: expose the global cancellation of manual compaction in disable_manual_compaction().

### DIFF
--- a/tests/cases/test_compact_range.rs
+++ b/tests/cases/test_compact_range.rs
@@ -53,15 +53,17 @@ fn test_compact_range() {
     for &(ref k, _) in &samples {
         db.delete(k).unwrap()
     }
-    let compact_opts = CompactOptions::new();
-    // Set manual compaction `canceled` flag is true to disallow manual compaction.
-    DB::set_global_manual_compaction_canceled(true);
     let handle = db.cf_handle("default").unwrap();
-    db.compact_range_cf_opt(handle, &compact_opts, None, None);
-    let new_size = db.get_approximate_sizes(&[Range::new(b"k0", b"k6")])[0];
-    assert_eq!(old_size, new_size);
-    // Reset manual compaction `canceled` flag to allow manual compaction.
-    DB::set_global_manual_compaction_canceled(false);
+    let compact_opts = CompactOptions::new();
+    // Set manual compaction flag to validate the cancellation of manual compaction.
+    for flag in [false, true] {
+        db.disable_manual_compaction(flag);
+        db.compact_range_cf_opt(handle, &compact_opts, None, None);
+        let new_size = db.get_approximate_sizes(&[Range::new(b"k0", b"k6")])[0];
+        assert_eq!(old_size, new_size);
+    }
+    // Reset and enable manual compactions.
+    db.enable_manual_compaction();
     db.compact_range_cf_opt(handle, &compact_opts, None, None);
     let new_size = db.get_approximate_sizes(&[Range::new(b"k0", b"k6")])[0];
     assert!(old_size > new_size);

--- a/tests/cases/test_compact_range.rs
+++ b/tests/cases/test_compact_range.rs
@@ -56,14 +56,13 @@ fn test_compact_range() {
     let handle = db.cf_handle("default").unwrap();
     let compact_opts = CompactOptions::new();
     // Set manual compaction flag to validate the cancellation of manual compaction.
-    for flag in [false, true] {
-        db.disable_manual_compaction(flag);
-        db.compact_range_cf_opt(handle, &compact_opts, None, None);
-        let new_size = db.get_approximate_sizes(&[Range::new(b"k0", b"k6")])[0];
-        assert_eq!(old_size, new_size);
-    }
-    // Reset and enable manual compactions.
+    db.disable_manual_compaction(true);
+    db.compact_range_cf_opt(handle, &compact_opts, None, None);
+    let new_size = db.get_approximate_sizes(&[Range::new(b"k0", b"k6")])[0];
+    assert_eq!(old_size, new_size);
+    // Re-enable manual compactions.
     db.enable_manual_compaction();
+    let compact_opts = CompactOptions::new();
     db.compact_range_cf_opt(handle, &compact_opts, None, None);
     let new_size = db.get_approximate_sizes(&[Range::new(b"k0", b"k6")])[0];
     assert!(old_size > new_size);


### PR DESCRIPTION
## Descriptions

Ref: https://github.com/tikv/tikv/issues/18396

After PR #826, the function `disable_manual_compaction` was enhanced to also stop in-progress manual compactions, whereas previously it would only prevent new and pending compactions in the compaction queue from running.

However, the current implementation doesn't properly support multi-database scenarios. To address this, we need to expose an option that controls whether to set the global canceled flag, allowing callers to stop all in-progress manual compactions when needed.

## Purpose of This PR
This PR enables `disable_manual_compaction` to optionally set the global canceled flag based on caller requirements.