### PR TITLE
Add blob_raw_size to Titan blob index FFI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,5 @@
 
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan
-	url = https://github.com/tikv/titan.git
-	branch = master
+	url = https://github.com/hbisheng/titan.git
+	branch = titan-properties

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -6854,6 +6854,7 @@ void ctitandb_decode_blob_index(const char* value, size_t value_size,
   index->file_number = bi.file_number;
   index->blob_offset = bi.blob_handle.offset;
   index->blob_size = bi.blob_handle.size;
+  index->blob_raw_size = bi.blob_handle.raw_size;
 }
 
 void ctitandb_encode_blob_index(const ctitandb_blob_index_t* index,
@@ -6862,6 +6863,7 @@ void ctitandb_encode_blob_index(const ctitandb_blob_index_t* index,
   bi.file_number = index->file_number;
   bi.blob_handle.offset = index->blob_offset;
   bi.blob_handle.size = index->blob_size;
+  bi.blob_handle.raw_size = index->blob_raw_size;
   std::string result;
   bi.EncodeTo(&result);
   *value = CopyString(result);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -2659,6 +2659,7 @@ struct ctitandb_blob_index_t {
   uint64_t file_number;
   uint64_t blob_offset;
   uint64_t blob_size;
+  uint64_t blob_raw_size;
 };
 
 typedef struct ctitandb_options_t ctitandb_options_t;

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -218,6 +218,7 @@ pub struct DBTitanBlobIndex {
     pub file_number: u64,
     pub blob_offset: u64,
     pub blob_size: u64,
+    pub blob_raw_size: u64,
 }
 
 pub fn new_bloom_filter(bits: c_double) -> *mut DBFilterPolicy {


### PR DESCRIPTION
Corresponding to https://github.com/tikv/titan/pull/334, this commit adds a `blob_raw_size` field to `ctitandb_blob_index_t` and its corresponding Rust binding (DBTitanBlobIndex). The field records the uncompressed size of the blob value.